### PR TITLE
Refactor work routes and schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "eub-backend-v2",
+  "name": "bwt-backend-v2",
   "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
@@ -3181,7 +3181,7 @@
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
-      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFecMpmHtPOSij8K99/wSfoEuTObmuMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "eub-backend-v2",
+  "name": "bwt-backend-v2",
   "type": "module",
   "version": "1.0.1",
   "license": "MIT",

--- a/src/lib/configure_open_api.ts
+++ b/src/lib/configure_open_api.ts
@@ -10,7 +10,7 @@ export default function configureOpenAPI(app: AppOpenAPI) {
     openapi: '3.0.0',
     info: {
       title: packageJSON.name,
-      description: 'EUB API Documentation',
+      description: 'BWT API Documentation',
       contact: { name: 'RBR', email: 'rafsan@fortunezip.com' },
       version: packageJSON.version,
     },

--- a/src/lib/nanoid.ts
+++ b/src/lib/nanoid.ts
@@ -2,7 +2,7 @@ import { customAlphabet } from 'nanoid';
 
 export const nanoid = customAlphabet(
   '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
-  21,
+  15,
 );
 
 export default nanoid;

--- a/src/lib/variables.ts
+++ b/src/lib/variables.ts
@@ -5,7 +5,7 @@ import type { ColumnProps } from './types';
 
 export function defaultUUID(column = 'uuid') {
   return char(column, {
-    length: 21,
+    length: 15,
   });
 }
 

--- a/src/routes/delivery/challan/routes.ts
+++ b/src/routes/delivery/challan/routes.ts
@@ -8,34 +8,34 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.challan_entry'];
+const tags = ['delivery.challan'];
 
 export const list = createRoute({
-  path: '/hr/challan_entry',
+  path: '/delivery/challan',
   method: 'get',
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of challan_entry',
+      'The list of challan',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/hr/challan_entry',
+  path: '/delivery/challan',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The challan_entry to create',
+      'The challan  to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created challan_entry',
+      'The created challan',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/challan_entry/{uuid}',
+  path: '/delivery/challan/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -54,11 +54,11 @@ export const getOne = createRoute({
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested challan_entry',
+      'The requested challan',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'challan_entry not found',
+      'challan not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +68,24 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/challan_entry/{uuid}',
+  path: '/delivery/challan/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
     body: jsonContentRequired(
       patchSchema,
-      'The challan_entry updates',
+      'The challan updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated challan_entry',
+      'The updated challan',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'challan_entry not found',
+      'challan not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/challan_entry/{uuid}',
+  path: '/delivery/challan/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,
@@ -104,11 +104,11 @@ export const remove = createRoute({
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'challan_entry deleted',
+      description: 'challan deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'challan_entry not found',
+      'challan not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),

--- a/src/routes/delivery/challan/utils.ts
+++ b/src/routes/delivery/challan/utils.ts
@@ -2,18 +2,16 @@ import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 
 import { dateTimePattern } from '@/utils';
 
-import { challan_entry } from '../schema';
+import { challan } from '../schema';
 
 //* crud
-export const selectSchema = createSelectSchema(challan_entry);
+export const selectSchema = createSelectSchema(challan);
 
 export const insertSchema = createInsertSchema(
-  challan_entry,
+  challan,
   {
-    uuid: schema => schema.uuid.length(21),
-    challan_uuid: schema => schema.challan_uuid.length(21),
-    order_uuid: schema => schema.order_uuid.length(21),
-    created_by: schema => schema.created_by.length(21),
+    uuid: schema => schema.uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),
@@ -24,8 +22,6 @@ export const insertSchema = createInsertSchema(
   },
 ).required({
   uuid: true,
-  challan_uuid: true,
-  order_uuid: true,
   created_by: true,
   created_at: true,
 }).partial({

--- a/src/routes/delivery/challan_entry/routes.ts
+++ b/src/routes/delivery/challan_entry/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.challan_entry'];
+const tags = ['delivery.challan_entry'];
 
 export const list = createRoute({
-  path: '/hr/challan-entry',
+  path: '/delivery/challan-entry',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/challan-entry',
+  path: '/delivery/challan-entry',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/challan-entry/{uuid}',
+  path: '/delivery/challan-entry/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/challan-entry/{uuid}',
+  path: '/delivery/challan-entry/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/challan-entry/{uuid}',
+  path: '/delivery/challan-entry/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/delivery/challan_entry/utils.ts
+++ b/src/routes/delivery/challan_entry/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(challan_entry);
 export const insertSchema = createInsertSchema(
   challan_entry,
   {
-    uuid: schema => schema.uuid.length(21),
-    challan_uuid: schema => schema.challan_uuid.length(21),
-    order_uuid: schema => schema.order_uuid.length(21),
-    created_by: schema => schema.created_by.length(21),
+    uuid: schema => schema.uuid.length(15),
+    challan_uuid: schema => schema.challan_uuid.length(15),
+    order_uuid: schema => schema.order_uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/delivery/courier/routes.ts
+++ b/src/routes/delivery/courier/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.courier'];
+const tags = ['delivery.courier'];
 
 export const list = createRoute({
-  path: '/hr/courier',
+  path: '/delivery/courier',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/courier',
+  path: '/delivery/courier',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/courier/{uuid}',
+  path: '/delivery/courier/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/courier/{uuid}',
+  path: '/delivery/courier/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/courier/{uuid}',
+  path: '/delivery/courier/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/delivery/courier/utils.ts
+++ b/src/routes/delivery/courier/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(courier);
 export const insertSchema = createInsertSchema(
   courier,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
     branch: schema => schema.branch.min(1),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/delivery/vehicle/routes.ts
+++ b/src/routes/delivery/vehicle/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.vehicle'];
+const tags = ['delivery.vehicle'];
 
 export const list = createRoute({
-  path: '/hr/vehicle',
+  path: '/delivery/vehicle',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/vehicle',
+  path: '/delivery/vehicle',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/vehicle/{uuid}',
+  path: '/delivery/vehicle/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/vehicle/{uuid}',
+  path: '/delivery/vehicle/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/vehicle/{uuid}',
+  path: '/delivery/vehicle/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/delivery/vehicle/utils.ts
+++ b/src/routes/delivery/vehicle/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(vehicle);
 export const insertSchema = createInsertSchema(
   vehicle,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
     no: schema => schema.no.min(1),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/hr/department/utils.ts
+++ b/src/routes/hr/department/utils.ts
@@ -10,7 +10,7 @@ export const selectSchema = createSelectSchema(department);
 export const insertSchema = createInsertSchema(
   department,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     department: schema => schema.department.min(1),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',

--- a/src/routes/hr/designation/utils.ts
+++ b/src/routes/hr/designation/utils.ts
@@ -10,7 +10,7 @@ export const selectSchema = createSelectSchema(designation);
 export const insertSchema = createInsertSchema(
   designation,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     designation: schema => schema.designation.min(1),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',

--- a/src/routes/hr/users/utils.ts
+++ b/src/routes/hr/users/utils.ts
@@ -29,7 +29,7 @@ export const signinOutputSchema = z.object({
 export const insertSchema = createInsertSchema(
   users,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     pass: schema => schema.pass.min(4).max(50),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',

--- a/src/routes/index.route.ts
+++ b/src/routes/index.route.ts
@@ -1,11 +1,13 @@
 import delivery from './delivery';
 import hr from './hr';
 import store from './store';
+import work from './work';
 
 const routes = [
   ...hr,
   ...delivery,
   ...store,
+  ...work,
 ] as const;
 
 export default routes;

--- a/src/routes/index.schema.ts
+++ b/src/routes/index.schema.ts
@@ -1,9 +1,13 @@
 import * as delivery from './delivery/schema';
 import * as hr from './hr/schema';
+import * as store from './store/schema';
+import * as work from './work/schema';
 
 const schema = {
   ...hr,
   ...delivery,
+  ...store,
+  ...work,
 };
 
 export type Schema = typeof schema;

--- a/src/routes/store/box/routes.ts
+++ b/src/routes/store/box/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.box'];
+const tags = ['store.box'];
 
 export const list = createRoute({
-  path: '/hr/box',
+  path: '/store/box',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/box',
+  path: '/store/box',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/box/{uuid}',
+  path: '/store/box/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/box/{uuid}',
+  path: '/store/box/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/box/{uuid}',
+  path: '/store/box/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/box/utils.ts
+++ b/src/routes/store/box/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(box);
 export const insertSchema = createInsertSchema(
   box,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    floor_uuid: schema => schema.floor_uuid.length(21),
-    created_by: schema => schema.created_by.length(21),
+    floor_uuid: schema => schema.floor_uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/branch/routes.ts
+++ b/src/routes/store/branch/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.branch'];
+const tags = ['store.branch'];
 
 export const list = createRoute({
-  path: '/hr/branch',
+  path: '/store/branch',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/branch',
+  path: '/store/branch',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/branch/{uuid}',
+  path: '/store/branch/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/branch/{uuid}',
+  path: '/store/branch/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/branch/{uuid}',
+  path: '/store/branch/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/branch/utils.ts
+++ b/src/routes/store/branch/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(branch);
 export const insertSchema = createInsertSchema(
   branch,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
     address: schema => schema.address.min(1),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/brand/routes.ts
+++ b/src/routes/store/brand/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.brand'];
+const tags = ['store.brand'];
 
 export const list = createRoute({
-  path: '/hr/brand',
+  path: '/store/brand',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/brand',
+  path: '/store/brand',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/brand/{uuid}',
+  path: '/store/brand/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/brand/{uuid}',
+  path: '/store/brand/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/brand/{uuid}',
+  path: '/store/brand/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/brand/utils.ts
+++ b/src/routes/store/brand/utils.ts
@@ -10,9 +10,9 @@ export const selectSchema = createSelectSchema(brand);
 export const insertSchema = createInsertSchema(
   brand,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/category/routes.ts
+++ b/src/routes/store/category/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.category'];
+const tags = ['store.category'];
 
 export const list = createRoute({
-  path: '/hr/category',
+  path: '/store/category',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/category',
+  path: '/store/category',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/category/{uuid}',
+  path: '/store/category/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/category/{uuid}',
+  path: '/store/category/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/category/{uuid}',
+  path: '/store/category/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/category/utils.ts
+++ b/src/routes/store/category/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(category);
 export const insertSchema = createInsertSchema(
   category,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    group_uuid: schema => schema.group_uuid.length(21),
-    created_by: schema => schema.created_by.length(21),
+    group_uuid: schema => schema.group_uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/floor/routes.ts
+++ b/src/routes/store/floor/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.floor'];
+const tags = ['store.floor'];
 
 export const list = createRoute({
-  path: '/hr/floor',
+  path: '/store/floor',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/floor',
+  path: '/store/floor',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/floor/{uuid}',
+  path: '/store/floor/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/floor/{uuid}',
+  path: '/store/floor/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/floor/{uuid}',
+  path: '/store/floor/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/floor/utils.ts
+++ b/src/routes/store/floor/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(floor);
 export const insertSchema = createInsertSchema(
   floor,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    rack_uuid: schema => schema.rack_uuid.length(21),
-    created_by: schema => schema.created_by.length(21),
+    rack_uuid: schema => schema.rack_uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/group/routes.ts
+++ b/src/routes/store/group/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.group'];
+const tags = ['store.group'];
 
 export const list = createRoute({
-  path: '/hr/group',
+  path: '/store/group',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/group',
+  path: '/store/group',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/group/{uuid}',
+  path: '/store/group/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/group/{uuid}',
+  path: '/store/group/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/group/{uuid}',
+  path: '/store/group/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/group/utils.ts
+++ b/src/routes/store/group/utils.ts
@@ -10,9 +10,9 @@ export const selectSchema = createSelectSchema(group);
 export const insertSchema = createInsertSchema(
   group,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/internal_transfer/routes.ts
+++ b/src/routes/store/internal_transfer/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.internal_transfer'];
+const tags = ['store.internal_transfer'];
 
 export const list = createRoute({
-  path: '/hr/internal-transfer',
+  path: '/store/internal-transfer',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/internal-transfer',
+  path: '/store/internal-transfer',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/internal-transfer/{uuid}',
+  path: '/store/internal-transfer/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/internal-transfer/{uuid}',
+  path: '/store/internal-transfer/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/internal-transfer/{uuid}',
+  path: '/store/internal-transfer/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/internal_transfer/utils.ts
+++ b/src/routes/store/internal_transfer/utils.ts
@@ -11,17 +11,17 @@ export const selectSchema = createSelectSchema(internal_transfer);
 export const insertSchema = createInsertSchema(
   internal_transfer,
   {
-    uuid: schema => schema.uuid.length(21),
-    product_uuid: schema => schema.product_uuid.length(21),
-    from_warehouse_uuid: schema => schema.from_warehouse_uuid.length(21),
-    to_warehouse_uuid: schema => schema.to_warehouse_uuid.length(21),
-    rack_uuid: schema => schema.rack_uuid.length(21),
-    floor_uuid: schema => schema.floor_uuid.length(21),
-    box_uuid: schema => schema.box_uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
+    product_uuid: schema => schema.product_uuid.length(15),
+    from_warehouse_uuid: schema => schema.from_warehouse_uuid.length(15),
+    to_warehouse_uuid: schema => schema.to_warehouse_uuid.length(15),
+    rack_uuid: schema => schema.rack_uuid.length(15),
+    floor_uuid: schema => schema.floor_uuid.length(15),
+    box_uuid: schema => schema.box_uuid.length(15),
     quantity: z.number().min(0, {
       message: 'quantity must be a positive number',
     }),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/model/routes.ts
+++ b/src/routes/store/model/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.model'];
+const tags = ['store.model'];
 
 export const list = createRoute({
-  path: '/hr/model',
+  path: '/store/model',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/model',
+  path: '/store/model',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/model/{uuid}',
+  path: '/store/model/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/model/{uuid}',
+  path: '/store/model/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/model/{uuid}',
+  path: '/store/model/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/model/utils.ts
+++ b/src/routes/store/model/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(model);
 export const insertSchema = createInsertSchema(
   model,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    brand_uuid: schema => schema.brand_uuid.length(21),
-    created_by: schema => schema.created_by.length(21),
+    brand_uuid: schema => schema.brand_uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/product/routes.ts
+++ b/src/routes/store/product/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.product'];
+const tags = ['store.product'];
 
 export const list = createRoute({
-  path: '/hr/product',
+  path: '/store/product',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/product',
+  path: '/store/product',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/product/{uuid}',
+  path: '/store/product/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/product/{uuid}',
+  path: '/store/product/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/product/{uuid}',
+  path: '/store/product/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/product/utils.ts
+++ b/src/routes/store/product/utils.ts
@@ -11,16 +11,16 @@ export const selectSchema = createSelectSchema(product);
 export const insertSchema = createInsertSchema(
   product,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    category_uuid: schema => schema.category_uuid.length(21),
-    model_uuid: schema => schema.model_uuid.length(21),
-    size_uuid: schema => schema.size_uuid.length(21),
+    category_uuid: schema => schema.category_uuid.length(15),
+    model_uuid: schema => schema.model_uuid.length(15),
+    size_uuid: schema => schema.size_uuid.length(15),
     warranty_days: z.boolean().optional().default(false),
     service_warranty_days: z.number().min(0).optional().default(0),
     type: z.string().optional().default('product'),
     is_maintaining_stock: z.boolean().optional().default(false),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/product_transfer/routes.ts
+++ b/src/routes/store/product_transfer/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.product_transfer'];
+const tags = ['store.product_transfer'];
 
 export const list = createRoute({
-  path: '/hr/product-transfer',
+  path: '/store/product-transfer',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/product-transfer',
+  path: '/store/product-transfer',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/product-transfer/{uuid}',
+  path: '/store/product-transfer/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/product-transfer/{uuid}',
+  path: '/store/product-transfer/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/product-transfer/{uuid}',
+  path: '/store/product-transfer/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/product_transfer/utils.ts
+++ b/src/routes/store/product_transfer/utils.ts
@@ -11,12 +11,12 @@ export const selectSchema = createSelectSchema(product_transfer);
 export const insertSchema = createInsertSchema(
   product_transfer,
   {
-    uuid: schema => schema.uuid.length(21),
-    product_uuid: schema => schema.product_uuid.length(21),
-    warehouse_uuid: schema => schema.warehouse_uuid.length(21),
-    order_uuid: schema => schema.order_uuid.length(21).optional(),
+    uuid: schema => schema.uuid.length(15),
+    product_uuid: schema => schema.product_uuid.length(15),
+    warehouse_uuid: schema => schema.warehouse_uuid.length(15),
+    order_uuid: schema => schema.order_uuid.length(15).optional(),
     quantity: z.number().int().positive(),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/purchase/utils.ts
+++ b/src/routes/store/purchase/utils.ts
@@ -10,14 +10,14 @@ export const selectSchema = createSelectSchema(purchase);
 export const insertSchema = createInsertSchema(
   purchase,
   {
-    uuid: schema => schema.uuid.length(21),
-    vendor_uuid: schema => schema.vendor_uuid.length(21),
-    branch_uuid: schema => schema.branch_uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
+    vendor_uuid: schema => schema.vendor_uuid.length(15),
+    branch_uuid: schema => schema.branch_uuid.length(15),
     date: schema => schema.date.regex(dateTimePattern, {
       message: 'date must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),
     payment_mode: schema => schema.payment_mode.min(1),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/purchase_entry/routes.ts
+++ b/src/routes/store/purchase_entry/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.purchase_entry'];
+const tags = ['store.purchase_entry'];
 
 export const list = createRoute({
-  path: '/hr/purchase-entry',
+  path: '/store/purchase-entry',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/purchase-entry',
+  path: '/store/purchase-entry',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/purchase-entry/{uuid}',
+  path: '/store/purchase-entry/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/purchase-entry/{uuid}',
+  path: '/store/purchase-entry/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/purchase-entry/{uuid}',
+  path: '/store/purchase-entry/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/purchase_entry/utils.ts
+++ b/src/routes/store/purchase_entry/utils.ts
@@ -10,9 +10,9 @@ export const selectSchema = createSelectSchema(purchase_entry);
 export const insertSchema = createInsertSchema(
   purchase_entry,
   {
-    uuid: schema => schema.uuid.length(21),
-    purchase_uuid: schema => schema.purchase_uuid.length(21),
-    product_uuid: schema => schema.product_uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
+    purchase_uuid: schema => schema.purchase_uuid.length(15),
+    product_uuid: schema => schema.product_uuid.length(15),
     serial_no: schema => schema.serial_no.length(50),
     quantity: schema => schema.quantity.min(1, {
       message: 'quantity must be at least 1',
@@ -21,11 +21,11 @@ export const insertSchema = createInsertSchema(
       message: 'price_per_unit must be at least 0',
     }),
     discount: schema => schema.discount.optional(),
-    warehouse_uuid: schema => schema.warehouse_uuid.length(21),
-    rack_uuid: schema => schema.rack_uuid.length(21),
-    floor_uuid: schema => schema.floor_uuid.length(21),
-    box_uuid: schema => schema.box_uuid.length(21),
-    created_by: schema => schema.created_by.length(21),
+    warehouse_uuid: schema => schema.warehouse_uuid.length(15),
+    rack_uuid: schema => schema.rack_uuid.length(15),
+    floor_uuid: schema => schema.floor_uuid.length(15),
+    box_uuid: schema => schema.box_uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/purchase_return/routes.ts
+++ b/src/routes/store/purchase_return/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.purchase_return'];
+const tags = ['store.purchase_return'];
 
 export const list = createRoute({
-  path: '/hr/purchase-return',
+  path: '/store/purchase-return',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/purchase-return',
+  path: '/store/purchase-return',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/purchase-return/{uuid}',
+  path: '/store/purchase-return/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/purchase-return/{uuid}',
+  path: '/store/purchase-return/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/purchase-return/{uuid}',
+  path: '/store/purchase-return/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/purchase_return/utils.ts
+++ b/src/routes/store/purchase_return/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(purchase_return);
 export const insertSchema = createInsertSchema(
   purchase_return,
   {
-    uuid: schema => schema.uuid.length(21),
-    purchase_uuid: schema => schema.purchase_uuid.length(21),
-    warehouse_uuid: schema => schema.warehouse_uuid.length(21),
-    created_by: schema => schema.created_by.length(21),
+    uuid: schema => schema.uuid.length(15),
+    purchase_uuid: schema => schema.purchase_uuid.length(15),
+    warehouse_uuid: schema => schema.warehouse_uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/purchase_return_entry/routes.ts
+++ b/src/routes/store/purchase_return_entry/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.purchase_return_entry'];
+const tags = ['store.purchase_return_entry'];
 
 export const list = createRoute({
-  path: '/hr/purchase-return-entry',
+  path: '/store/purchase-return-entry',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/purchase-return-entry',
+  path: '/store/purchase-return-entry',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/purchase-return-entry/{uuid}',
+  path: '/store/purchase-return-entry/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/purchase-return-entry/{uuid}',
+  path: '/store/purchase-return-entry/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/purchase-return-entry/{uuid}',
+  path: '/store/purchase-return-entry/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/purchase_return_entry/utils.ts
+++ b/src/routes/store/purchase_return_entry/utils.ts
@@ -10,16 +10,16 @@ export const selectSchema = createSelectSchema(purchase_return_entry);
 export const insertSchema = createInsertSchema(
   purchase_return_entry,
   {
-    uuid: schema => schema.uuid.length(21),
-    purchase_return_uuid: schema => schema.purchase_return_uuid.length(21),
-    product_uuid: schema => schema.product_uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
+    purchase_return_uuid: schema => schema.purchase_return_uuid.length(15),
+    product_uuid: schema => schema.product_uuid.length(15),
     quantity: schema => schema.quantity.min(1, {
       message: 'quantity must be at least 1',
     }),
     price_per_unit: schema => schema.price_per_unit.min(0, {
       message: 'price_per_unit must be at least 0',
     }),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/rack/routes.ts
+++ b/src/routes/store/rack/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.rack'];
+const tags = ['store.rack'];
 
 export const list = createRoute({
-  path: '/hr/rack',
+  path: '/store/rack',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/rack',
+  path: '/store/rack',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/rack/{uuid}',
+  path: '/store/rack/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/rack/{uuid}',
+  path: '/store/rack/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/rack/{uuid}',
+  path: '/store/rack/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/rack/utils.ts
+++ b/src/routes/store/rack/utils.ts
@@ -10,10 +10,10 @@ export const selectSchema = createSelectSchema(rack);
 export const insertSchema = createInsertSchema(
   rack,
   {
-    uuid: schema => schema.uuid.length(21),
-    warehouse_uuid: schema => schema.warehouse_uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
+    warehouse_uuid: schema => schema.warehouse_uuid.length(15),
     name: schema => schema.name.min(1),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/size/routes.ts
+++ b/src/routes/store/size/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.size'];
+const tags = ['store.size'];
 
 export const list = createRoute({
-  path: '/hr/size',
+  path: '/store/size',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/size',
+  path: '/store/size',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/size/{uuid}',
+  path: '/store/size/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/size/{uuid}',
+  path: '/store/size/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/size/{uuid}',
+  path: '/store/size/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/size/utils.ts
+++ b/src/routes/store/size/utils.ts
@@ -10,9 +10,9 @@ export const selectSchema = createSelectSchema(size);
 export const insertSchema = createInsertSchema(
   size,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/stock/routes.ts
+++ b/src/routes/store/stock/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.stock'];
+const tags = ['store.stock'];
 
 export const list = createRoute({
-  path: '/hr/stock',
+  path: '/store/stock',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/stock',
+  path: '/store/stock',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/stock/{uuid}',
+  path: '/store/stock/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/stock/{uuid}',
+  path: '/store/stock/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/stock/{uuid}',
+  path: '/store/stock/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/stock/utils.ts
+++ b/src/routes/store/stock/utils.ts
@@ -10,12 +10,12 @@ export const selectSchema = createSelectSchema(stock);
 export const insertSchema = createInsertSchema(
   stock,
   {
-    uuid: schema => schema.uuid.length(21),
-    product_uuid: schema => schema.product_uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
+    product_uuid: schema => schema.product_uuid.length(15),
     warehouse_1: schema => schema.warehouse_1.optional(),
     warehouse_2: schema => schema.warehouse_2.optional(),
     warehouse_3: schema => schema.warehouse_3.optional(),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/vendor/routes.ts
+++ b/src/routes/store/vendor/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.vendor'];
+const tags = ['store.vendor'];
 
 export const list = createRoute({
-  path: '/hr/vendor',
+  path: '/store/vendor',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/vendor',
+  path: '/store/vendor',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/vendor/{uuid}',
+  path: '/store/vendor/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/vendor/{uuid}',
+  path: '/store/vendor/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/vendor/{uuid}',
+  path: '/store/vendor/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/vendor/utils.ts
+++ b/src/routes/store/vendor/utils.ts
@@ -11,15 +11,15 @@ export const selectSchema = createSelectSchema(vendor);
 export const insertSchema = createInsertSchema(
   vendor,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    model_uuid: schema => schema.model_uuid.length(21),
+    model_uuid: schema => schema.model_uuid.length(15),
     company_name: schema => schema.company_name.min(1),
     phone: schema => schema.phone.min(1).max(15),
     address: schema => schema.address.min(1),
     description: schema => schema.description.optional(),
     is_active: z.boolean().default(false),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/store/warehouse/routes.ts
+++ b/src/routes/store/warehouse/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.warehouse'];
+const tags = ['store.warehouse'];
 
 export const list = createRoute({
-  path: '/hr/warehouse',
+  path: '/store/warehouse',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/warehouse',
+  path: '/store/warehouse',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/warehouse/{uuid}',
+  path: '/store/warehouse/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/warehouse/{uuid}',
+  path: '/store/warehouse/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/warehouse/{uuid}',
+  path: '/store/warehouse/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/store/warehouse/utils.ts
+++ b/src/routes/store/warehouse/utils.ts
@@ -10,11 +10,11 @@ export const selectSchema = createSelectSchema(warehouse);
 export const insertSchema = createInsertSchema(
   warehouse,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     name: schema => schema.name.min(1),
-    branch_uuid: schema => schema.branch_uuid.length(21),
+    branch_uuid: schema => schema.branch_uuid.length(15),
     assigned: schema => schema.assigned.optional(),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/work/accessory/routes.ts
+++ b/src/routes/work/accessory/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.accessory'];
+const tags = ['work.accessory'];
 
 export const list = createRoute({
-  path: '/hr/accessory',
+  path: '/work/accessory',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/accessory',
+  path: '/work/accessory',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/accessory/{uuid}',
+  path: '/work/accessory/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/accessory/{uuid}',
+  path: '/work/accessory/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/accessory/{uuid}',
+  path: '/work/accessory/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/work/diagnosis/routes.ts
+++ b/src/routes/work/diagnosis/routes.ts
@@ -8,10 +8,10 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.diagnosis'];
+const tags = ['work.diagnosis'];
 
 export const list = createRoute({
-  path: '/hr/diagnosis',
+  path: '/work/diagnosis',
   method: 'get',
   tags,
   responses: {
@@ -23,7 +23,7 @@ export const list = createRoute({
 });
 
 export const create = createRoute({
-  path: '/hr/diagnosis',
+  path: '/work/diagnosis',
   method: 'post',
   request: {
     body: jsonContentRequired(
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/diagnosis/{uuid}',
+  path: '/work/diagnosis/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -68,7 +68,7 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/diagnosis/{uuid}',
+  path: '/work/diagnosis/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/diagnosis/{uuid}',
+  path: '/work/diagnosis/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,

--- a/src/routes/work/diagnosis/utils.ts
+++ b/src/routes/work/diagnosis/utils.ts
@@ -11,16 +11,16 @@ export const selectSchema = createSelectSchema(diagnosis);
 export const insertSchema = createInsertSchema(
   diagnosis,
   {
-    uuid: schema => schema.uuid.length(21),
+    uuid: schema => schema.uuid.length(15),
     order_uuid: schema => schema.order_uuid.min(1),
-    engineer_uuid: schema => schema.engineer_uuid.length(21),
+    engineer_uuid: schema => schema.engineer_uuid.length(15),
     problems_uuid: schema => schema.problems_uuid.array().optional(),
     problem_statement: schema => schema.problem_statement.optional(),
     status: schema => schema.status.optional(),
     status_update_date: schema => schema.status_update_date.optional(),
     proposed_cost: z.number().optional().default(0),
     is_proceed_to_repair: schema => schema.is_proceed_to_repair.optional(),
-    created_by: schema => schema.created_by.length(21),
+    created_by: schema => schema.created_by.length(15),
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),

--- a/src/routes/work/index.ts
+++ b/src/routes/work/index.ts
@@ -1,0 +1,9 @@
+import accessory from './accessory';
+import diagnosis from './diagnosis';
+import info from './info';
+
+export default [
+  accessory,
+  diagnosis,
+  info,
+];

--- a/src/routes/work/info/handlers.ts
+++ b/src/routes/work/info/handlers.ts
@@ -1,0 +1,279 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq, sql } from 'drizzle-orm';
+import { alias } from 'drizzle-orm/pg-core';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { nanoid } from '@/lib/nanoid';
+import * as deliverySchema from '@/routes/delivery/schema';
+import * as hrSchema from '@/routes/hr/schema';
+import { users } from '@/routes/hr/schema';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { info, order, zone } from '../schema';
+
+const user = alias(hrSchema.users, 'user');
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const {
+    is_new_customer,
+    user_uuid,
+    name,
+    phone,
+    created_at,
+    department_uuid,
+    designation_uuid,
+    business_type,
+    where_they_find_us,
+    submitted_by,
+  } = value;
+
+  let userUuid = user_uuid;
+  if (is_new_customer) {
+    const formattedName = name.toLowerCase().replace(/\s+/g, '');
+    await db.insert(users).values({
+      uuid: userUuid,
+      name,
+      phone,
+      user_type: 'customer',
+      pass: phone,
+      department_uuid,
+      designation_uuid,
+      email: `${formattedName + phone}@bwt.com`,
+      ext: '+880',
+      created_at,
+      business_type,
+      where_they_find_us,
+    });
+  }
+  if (submitted_by === 'customer') {
+    const formattedName2 = name.toLowerCase().replace(/\s+/g, '');
+
+    const existingUser = await db
+      .select()
+      .from(users)
+      .where(eq(users.phone, phone))
+      .limit(1);
+
+    userUuid = existingUser[0]?.uuid || userUuid;
+
+    if (existingUser.length === 0) {
+      userUuid = nanoid();
+
+      await db.insert(users).values({
+        uuid: userUuid,
+        name,
+        phone,
+        user_type: 'customer',
+        pass: phone,
+        email: `${formattedName2 + phone}@bwt.com`,
+        ext: '+880',
+        created_at,
+      });
+    }
+  }
+
+  const [data] = await db.insert(info).values({ ...value, user_uuid: userUuid }).returning({
+    name: info.uuid,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const {
+    is_new_customer,
+    user_uuid,
+    name,
+    phone,
+    updated_at,
+    department_uuid,
+    designation_uuid,
+    business_type,
+    where_they_find_us,
+  } = updates;
+
+  if (is_new_customer) {
+    const formattedName = name.toLowerCase().replace(/\s+/g, '');
+    await db.insert(users).values({
+      uuid: user_uuid,
+      name,
+      phone,
+      user_type: 'customer',
+      pass: phone,
+      department_uuid,
+      designation_uuid,
+      email: `${formattedName + phone}@bwt.com`,
+      ext: '+880',
+      created_at: updated_at,
+      business_type,
+      where_they_find_us,
+    });
+  }
+
+  const [data] = await db.update(info)
+    .set(updates)
+    .where(eq(info.uuid, uuid))
+    .returning({
+      name: info.uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(info)
+    .where(eq(info.uuid, uuid))
+    .returning({
+      name: info.uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  const { customer_uuid, status } = c.req.valid('query');
+
+  const orderCountSubquery = db
+    .select({
+      info_uuid: order.info_uuid,
+      order_count: sql`COUNT(*)`.as('order_count'),
+    })
+    .from(order)
+    .groupBy(order.info_uuid)
+    .as('order_count_tbl');
+
+  const deliveredCountSubquery = db
+    .select({
+      info_uuid: order.info_uuid,
+      delivered_count: sql`COUNT(*)`.as('delivered_count'),
+    })
+    .from(deliverySchema.challan)
+    .leftJoin(
+      deliverySchema.challan_entry,
+      eq(
+        deliverySchema.challan.uuid,
+        deliverySchema.challan_entry.challan_uuid,
+      ),
+    )
+    .leftJoin(
+      order,
+      eq(deliverySchema.challan_entry.order_uuid, order.uuid),
+    )
+    .where(sql`delivery."challan".is_delivery_complete = 'true'`)
+    .groupBy(order.info_uuid)
+    .as('delivered_count_tbl');
+
+  const infoPromise = db
+    .select({
+      id: info.id,
+      info_id: sql`CONCAT('WI', TO_CHAR(${info.created_at}::timestamp, 'YY'), '-', TO_CHAR(${info.id}, 'FM0000'))`,
+      uuid: info.uuid,
+      user_uuid: info.user_uuid,
+      user_id: sql`CONCAT('HU', TO_CHAR(${user.created_at}::timestamp, 'YY'), '-', TO_CHAR(${user.id}, 'FM0000'))`,
+      user_name: user.name,
+      user_phone: user.phone,
+      received_date: info.received_date,
+      is_product_received: info.is_product_received,
+      created_by: info.created_by,
+      created_by_name: hrSchema.users.name,
+      created_at: info.created_at,
+      updated_at: info.updated_at,
+      remarks: info.remarks,
+      location: info.location,
+      zone_uuid: info.zone_uuid,
+      zone_name: zone.name,
+      submitted_by: info.submitted_by,
+      order_count:
+        sql`COALESCE(order_count_tbl.order_count::float8, 0)`,
+      delivered_count:
+        sql`COALESCE(delivered_count_tbl.delivered_count::float8, 0)`,
+    })
+    .from(info)
+    .leftJoin(user, eq(info.user_uuid, user.uuid))
+    .leftJoin(hrSchema.users, eq(info.created_by, hrSchema.users.uuid))
+    .leftJoin(zone, eq(info.zone_uuid, zone.uuid))
+    .leftJoin(
+      orderCountSubquery,
+      eq(info.uuid, orderCountSubquery.info_uuid),
+    )
+    .leftJoin(
+      deliveredCountSubquery,
+      eq(info.uuid, deliveredCountSubquery.info_uuid),
+    );
+
+  if (customer_uuid) {
+    infoPromise.where(eq(info.user_uuid, customer_uuid));
+  }
+  if (status === 'pending') {
+    infoPromise.where(
+      sql`COALESCE(order_count_tbl.order_count, 0) != COALESCE(delivered_count_tbl.delivered_count, 0)`,
+    );
+  }
+  if (status === 'complete') {
+    infoPromise.where(
+      sql`COALESCE(order_count_tbl.order_count, 0) = COALESCE(delivered_count_tbl.delivered_count, 0) AND COALESCE(order_count_tbl.order_count, 0) > 0 AND COALESCE(delivered_count_tbl.delivered_count, 0) > 0`,
+    );
+  }
+
+  const data = await infoPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const infoPromise = db
+    .select({
+      id: info.id,
+      info_id: sql`CONCAT('WI', TO_CHAR(${info.created_at}::timestamp, 'YY'), '-', TO_CHAR(${info.id}, 'FM0000'))`,
+      uuid: info.uuid,
+      user_uuid: info.user_uuid,
+      user_id: sql`CONCAT('HU', TO_CHAR(${user.created_at}::timestamp, 'YY'), '-', TO_CHAR(${user.id}, 'FM0000'))`,
+      user_name: user.name,
+      user_phone: user.phone,
+      received_date: info.received_date,
+      is_product_received: info.is_product_received,
+      created_by: info.created_by,
+      created_by_name: hrSchema.users.name,
+      created_at: info.created_at,
+      updated_at: info.updated_at,
+      remarks: info.remarks,
+      location: info.location,
+      zone_uuid: info.zone_uuid,
+      zone_name: zone.name,
+      submitted_by: info.submitted_by,
+    })
+    .from(info)
+    .leftJoin(user, eq(info.user_uuid, user.uuid))
+    .leftJoin(hrSchema.users, eq(info.created_by, hrSchema.users.uuid))
+    .leftJoin(zone, eq(info.zone_uuid, zone.uuid))
+    .where(eq(info.uuid, uuid));
+
+  const data = await infoPromise;
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/work/info/index.ts
+++ b/src/routes/work/info/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/work/info/routes.ts
+++ b/src/routes/work/info/routes.ts
@@ -8,34 +8,40 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['store.purchase'];
+const tags = ['work.info'];
 
 export const list = createRoute({
-  path: '/store/purchase',
+  path: '/work/info',
   method: 'get',
   tags,
+  request: {
+    query: z.object({
+      customer_uuid: z.string().optional(),
+      status: z.string().optional(),
+    }),
+  },
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of purchase',
+      'The list of info',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/store/purchase',
+  path: '/work/info',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The purchase to create',
+      'The info to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created purchase',
+      'The created info',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,7 +51,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/store/purchase/{uuid}',
+  path: '/work/info/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -54,11 +60,11 @@ export const getOne = createRoute({
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested purchase',
+      'The requested info',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'purchase not found',
+      'info not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +74,24 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/store/purchase/{uuid}',
+  path: '/work/info/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
     body: jsonContentRequired(
       patchSchema,
-      'The purchase updates',
+      'The info updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated purchase',
+      'The updated info',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'purchase not found',
+      'info not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,7 +102,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/store/purchase/{uuid}',
+  path: '/work/info/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,
@@ -104,11 +110,11 @@ export const remove = createRoute({
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'purchase deleted',
+      description: 'info deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'purchase not found',
+      'info not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),

--- a/src/routes/work/info/utils.ts
+++ b/src/routes/work/info/utils.ts
@@ -2,17 +2,22 @@ import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 
 import { dateTimePattern } from '@/utils';
 
-import { accessory } from '../schema';
+import { info } from '../schema';
 
 //* crud
-export const selectSchema = createSelectSchema(accessory);
+export const selectSchema = createSelectSchema(info);
 
 export const insertSchema = createInsertSchema(
-  accessory,
+  info,
   {
     uuid: schema => schema.uuid.length(15),
-    name: schema => schema.name.min(1),
+    user_uuid: schema => schema.user_uuid.length(15),
+    received_date: schema => schema.received_date.regex(dateTimePattern, {
+      message: 'received_date must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    zone_uuid: schema => schema.zone_uuid.length(15),
     created_by: schema => schema.created_by.length(15),
+
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),
@@ -23,10 +28,16 @@ export const insertSchema = createInsertSchema(
   },
 ).required({
   uuid: true,
-  name: true,
+  id: true,
+  user_uuid: true,
+  zone_uuid: true,
   created_by: true,
   created_at: true,
 }).partial({
+  received_date: true,
+  is_product_received: true,
+  location: true,
+  submitted_by: true,
   updated_at: true,
   remarks: true,
 });

--- a/src/routes/work/order/handlers.ts
+++ b/src/routes/work/order/handlers.ts
@@ -1,0 +1,418 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { nanoid } from '@/lib/nanoid';
+import * as storeSchema from '@/routes/store/schema';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { order } from '../schema';
+
+// const user = alias(hrSchema.users, 'user');
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const {
+    model_uuid,
+    brand_uuid,
+    created_by,
+    created_at,
+  } = value;
+
+  let finalModelUuid = model_uuid;
+
+  if (model_uuid) {
+    const model = await db
+      .select()
+      .from(storeSchema.model)
+      .where(eq(storeSchema.model.uuid, model_uuid))
+      .limit(1);
+
+    if (model.length === 0) {
+      const [newModel] = await db
+        .insert(storeSchema.model)
+        .values({
+          uuid: nanoid(),
+          brand_uuid,
+          name: model_uuid,
+          created_by,
+          created_at,
+        })
+        .returning({
+          uuid: storeSchema.model.uuid,
+        });
+
+      finalModelUuid = newModel.uuid;
+    }
+  }
+
+  const [data] = await db.insert(order).values({ ...value, model_uuid: finalModelUuid }).returning({
+    name: order.uuid,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const {
+    model_uuid,
+    brand_uuid,
+    created_by,
+    updated_at,
+  } = updates;
+
+  let finalModelUuid = model_uuid;
+  if (model_uuid) {
+    const model = await db
+      .select()
+      .from(storeSchema.model)
+      .where(eq(storeSchema.model.uuid, model_uuid))
+      .limit(1);
+
+    if (model.length === 0) {
+      const [newModel] = await db
+        .insert(storeSchema.model)
+        .values({
+          uuid: nanoid(),
+          brand_uuid,
+          name: model_uuid,
+          created_by,
+          created_at: updated_at,
+        })
+        .returning({
+          uuid: storeSchema.model.uuid,
+        });
+      finalModelUuid = newModel.uuid;
+    }
+  }
+  const [data] = await db.update(order)
+    .set({ ...updates, model_uuid: finalModelUuid })
+    .where(eq(order.uuid, uuid))
+    .returning({
+      name: order.uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(order)
+    .where(eq(order.uuid, uuid))
+    .returning({
+      name: order.uuid,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+// export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+//   const { qc, is_delivered, work_in_hand, customer_uuid, is_repair } = c.req.valid('query');
+
+//   const orderPromise = db
+//     .select({
+//       id: order.id,
+//       order_id: sql`CONCAT('WO', TO_CHAR(${order.created_at}, 'YY'), '-', TO_CHAR(${order.id}, 'FM0000'))`,
+//       uuid: order.uuid,
+//       info_uuid: order.info_uuid,
+//       user_uuid: info.user_uuid,
+//       user_id: sql`CONCAT('HU', TO_CHAR(${user.created_at}::timestamp, 'YY'), '-', TO_CHAR(${user.id}::integer, 'FM0000'))`,
+//       user_name: user.name,
+//       user_phone: user.phone,
+//       model_uuid: order.model_uuid,
+//       model_name: storeSchema.model.name,
+//       brand_uuid: order.brand_uuid,
+//       brand_name: storeSchema.brand.name,
+//       serial_no: order.serial_no,
+//       problems_uuid: order.problems_uuid,
+//       problem_statement: order.problem_statement,
+//       accessories: order.accessories,
+//       is_product_received: info.is_product_received,
+//       received_date: info.received_date,
+//       warehouse_uuid: order.warehouse_uuid,
+//       warehouse_name: storeSchema.warehouse.name,
+//       rack_uuid: order.rack_uuid,
+//       rack_name: storeSchema.rack.name,
+//       floor_uuid: order.floor_uuid,
+//       floor_name: storeSchema.floor.name,
+//       box_uuid: order.box_uuid,
+//       box_name: storeSchema.box.name,
+//       created_by: order.created_by,
+//       created_by_name: hrSchema.users.name,
+//       created_at: order.created_at,
+//       updated_at: order.updated_at,
+//       remarks: order.remarks,
+//       is_diagnosis_need: order.is_diagnosis_need,
+//       quantity: order.quantity,
+//       info_id: sql`CONCAT('WI', TO_CHAR(${info.created_at}::timestamp, 'YY'), '-', TO_CHAR(${info.id}, 'FM0000'))`,
+//       is_transferred_for_qc: order.is_transferred_for_qc,
+//       is_ready_for_delivery: order.is_ready_for_delivery,
+//       is_proceed_to_repair: order.is_proceed_to_repair,
+//       branch_uuid: storeSchema.warehouse.branch_uuid,
+//       branch_name: storeSchema.branch.name,
+//       repairing_problems_uuid: order.repairing_problems_uuid,
+//       qc_problems_uuid: order.qc_problems_uuid,
+//       delivery_problems_uuid: order.delivery_problems_uuid,
+//       repairing_problem_statement: order.repairing_problem_statement,
+//       qc_problem_statement: order.qc_problem_statement,
+//       delivery_problem_statement: order.delivery_problem_statement,
+//       ready_for_delivery_date: order.ready_for_delivery_date,
+//       diagnosis_problems_uuid: diagnosis.problems_uuid,
+//       diagnosis_problem_statement: diagnosis.problem_statement,
+//       bill_amount: PG_DECIMAL_TO_FLOAT(order.bill_amount),
+//       is_home_repair: order.is_home_repair,
+//       proposed_cost: v(order.proposed_cost),
+//       is_challan_needed: order.is_challan_needed,
+//     })
+//     .from(order)
+//     .leftJoin(hrSchema.users, eq(order.created_by, hrSchema.users.uuid))
+//     .leftJoin(
+//       storeSchema.model,
+//       eq(order.model_uuid, storeSchema.model.uuid),
+//     )
+//     .leftJoin(
+//       storeSchema.brand,
+//       eq(order.brand_uuid, storeSchema.brand.uuid),
+//     )
+//     .leftJoin(
+//       storeSchema.warehouse,
+//       eq(order.warehouse_uuid, storeSchema.warehouse.uuid),
+//     )
+//     .leftJoin(storeSchema.rack, eq(order.rack_uuid, storeSchema.rack.uuid))
+//     .leftJoin(
+//       storeSchema.floor,
+//       eq(order.floor_uuid, storeSchema.floor.uuid),
+//     )
+//     .leftJoin(storeSchema.box, eq(order.box_uuid, storeSchema.box.uuid))
+//     .leftJoin(info, eq(order.info_uuid, info.uuid))
+//     .leftJoin(user, eq(info.user_uuid, user.uuid))
+//     .leftJoin(
+//       storeSchema.branch,
+//       eq(storeSchema.warehouse.branch_uuid, storeSchema.branch.uuid),
+//     )
+//     .leftJoin(diagnosis, eq(order.uuid, diagnosis.order_uuid))
+//     .orderBy(desc(order.created_at));
+
+//   const filters = [];
+
+//   if (qc === 'true') {
+//     filters.push(
+//       and(
+//         eq(order.is_transferred_for_qc, true),
+//         eq(order.is_ready_for_delivery, false),
+//       ),
+//     );
+//   }
+
+//   if (is_delivered === 'true') {
+//     filters.push(eq(order.is_ready_for_delivery, true));
+//   }
+
+//   if (work_in_hand === 'true') {
+//     filters.push(
+//       and(
+//         eq(order.is_transferred_for_qc, false),
+//         eq(order.is_ready_for_delivery, false),
+//       ),
+//     );
+//   }
+
+//   if (customer_uuid) {
+//     filters.push(
+//       and(
+//         eq(info.user_uuid, customer_uuid),
+//         or(
+//           eq(order.is_ready_for_delivery, true),
+//           eq(order.is_challan_needed, true),
+//         ),
+//         not(
+//           exists(
+//             db
+//               .select()
+//               .from(deliverySchema.challan_entry)
+//               .where(
+//                 eq(
+//                   deliverySchema.challan_entry.order_uuid,
+//                   order.uuid,
+//                 ),
+//               ),
+//           ),
+//         ),
+//       ),
+//     );
+//   }
+//   if (is_repair === 'true') {
+//     filters.push(
+//       and(
+//         eq(order.is_proceed_to_repair, true),
+//         eq(order.is_transferred_for_qc, false),
+//         eq(order.is_ready_for_delivery, false),
+//       ),
+//     );
+//   }
+
+//   if (filters.length > 0) {
+//     orderPromise.where(and(...filters));
+//   }
+
+//   const data = await orderPromise;
+
+//   const orderProblemsUUIDs = data
+//     .map(order => order.problems_uuid)
+//     .flat();
+//   const diagnosisProblemsUUIDs = data
+//     .map(order => order.diagnosis_problems_uuid)
+//     .flat();
+//   const repairingProblemsUUIDs = data
+//     .map(order => order.repairing_problems_uuid)
+//     .flat();
+//   const qcProblemsUUIDs = data
+//     .map(order => order.qc_problems_uuid)
+//     .flat();
+//   const deliveryProblemsUUIDs = data
+//     .map(order => order.delivery_problems_uuid)
+//     .flat();
+
+//   const allProblemsUUIDs = Array.from(
+//     new Set([
+//       ...orderProblemsUUIDs,
+//       ...diagnosisProblemsUUIDs,
+//       ...repairingProblemsUUIDs,
+//       ...qcProblemsUUIDs,
+//       ...deliveryProblemsUUIDs,
+//     ]),
+//   );
+
+//   const problems = await db
+//     .select({
+//       name: problem.name,
+//       uuid: problem.uuid,
+//     })
+//     .from(problem)
+//     .where(inArray(problem.uuid, allProblemsUUIDs));
+
+//   const problemsMap: Record<string, string> = problems.reduce((acc, problem) => {
+//     if (problem.uuid && problem.name) {
+//       acc[problem.uuid] = problem.name;
+//     }
+//     return acc;
+//   }, {} as Record<string, string>);
+
+//   const accessories_uuid = data.map(order => order.accessories).flat();
+
+//   const accessories = await db
+//     .select({
+//       name: accessory.name,
+//       uuid: accessory.uuid,
+//     })
+//     .from(accessory)
+//     .where(inArray(accessory.uuid, accessories_uuid));
+
+//   const accessoriesMap = accessories.reduce((acc, accessory) => {
+//     acc[accessory.uuid] = accessory.name;
+//     return acc;
+//   }, {});
+
+//   data.forEach((order) => {
+//     order.order_problems_name = (order.problems_uuid || []).map(
+//       uuid => problemsMap[uuid],
+//     );
+//     order.diagnosis_problems_name = (
+//       order.diagnosis_problems_uuid || []
+//     ).map(uuid => problemsMap[uuid]);
+//     order.repairing_problems_name = (
+//       order.repairing_problems_uuid || []
+//     ).map(uuid => problemsMap[uuid]);
+//     order.qc_problems_name = (order.qc_problems_uuid || []).map(
+//       uuid => problemsMap[uuid],
+//     );
+//     order.delivery_problems_name = (
+//       order.delivery_problems_uuid || []
+//     ).map(uuid => problemsMap[uuid]);
+//     order.accessories_name = (order.accessories || []).map(
+//       uuid => accessoriesMap[uuid],
+//     );
+//   });
+
+//   if (is_repair === 'true') {
+//     const api = await createApi(req);
+
+//     const fetchData = async endpoint =>
+//       await api
+//         .get(`${endpoint}`)
+//         .then(response => response.data)
+//         .catch((error) => {
+//           console.error(
+//             `Error fetching data from ${endpoint}:`,
+//             error.message,
+//           );
+//           throw error;
+//         });
+
+//     // Fetch product transfer data for each order
+//     for (const order of data) {
+//       const productTransfer = await fetchData(
+//         `/store/product-transfer/by/${order.uuid}`,
+//       );
+//       order.product_transfer = productTransfer?.data || [];
+//     }
+//   }
+
+//   return c.json(data || [], HSCode.OK);
+// };
+
+// export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+//   const { uuid } = c.req.valid('param');
+
+//   const infoPromise = db
+//     .select({
+//       id: info.id,
+//       info_id: sql`CONCAT('WI', TO_CHAR(${info.created_at}::timestamp, 'YY'), '-', TO_CHAR(${info.id}, 'FM0000'))`,
+//       uuid: info.uuid,
+//       user_uuid: info.user_uuid,
+//       user_id: sql`CONCAT('HU', TO_CHAR(${user.created_at}::timestamp, 'YY'), '-', TO_CHAR(${user.id}, 'FM0000'))`,
+//       user_name: user.name,
+//       user_phone: user.phone,
+//       received_date: info.received_date,
+//       is_product_received: info.is_product_received,
+//       created_by: info.created_by,
+//       created_by_name: hrSchema.users.name,
+//       created_at: info.created_at,
+//       updated_at: info.updated_at,
+//       remarks: info.remarks,
+//       location: info.location,
+//       zone_uuid: info.zone_uuid,
+//       zone_name: zone.name,
+//       submitted_by: info.submitted_by,
+//     })
+//     .from(info)
+//     .leftJoin(user, eq(info.user_uuid, user.uuid))
+//     .leftJoin(hrSchema.users, eq(info.created_by, hrSchema.users.uuid))
+//     .leftJoin(zone, eq(info.zone_uuid, zone.uuid))
+//     .where(eq(info.uuid, uuid));
+
+//   const data = await infoPromise;
+
+//   if (!data)
+//     return DataNotFound(c);
+
+//   return c.json(data || {}, HSCode.OK);
+// };

--- a/src/routes/work/order/index.ts
+++ b/src/routes/work/order/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  // .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  // .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/work/order/routes.ts
+++ b/src/routes/work/order/routes.ts
@@ -8,34 +8,43 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['store.purchase'];
+const tags = ['work.order'];
 
 export const list = createRoute({
-  path: '/store/purchase',
+  path: '/work/order',
   method: 'get',
   tags,
+  request: {
+    query: z.object({
+      qc: z.string().optional(),
+      is_delivered: z.string().optional(),
+      work_in_hand: z.string().optional(),
+      customer_uuid: z.string().optional(),
+      is_repair: z.string().optional(),
+    }),
+  },
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of purchase',
+      'The list of order',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/store/purchase',
+  path: '/work/order',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The purchase to create',
+      'The order to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created purchase',
+      'The created order',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,7 +54,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/store/purchase/{uuid}',
+  path: '/work/order/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -54,11 +63,11 @@ export const getOne = createRoute({
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested purchase',
+      'The requested order',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'purchase not found',
+      'order not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +77,24 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/store/purchase/{uuid}',
+  path: '/work/order/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
     body: jsonContentRequired(
       patchSchema,
-      'The purchase updates',
+      'The order updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated purchase',
+      'The updated order',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'purchase not found',
+      'order not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,7 +105,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/store/purchase/{uuid}',
+  path: '/work/order/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,
@@ -104,11 +113,11 @@ export const remove = createRoute({
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'purchase deleted',
+      description: 'order deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'purchase not found',
+      'order not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),

--- a/src/routes/work/order/utils.ts
+++ b/src/routes/work/order/utils.ts
@@ -2,17 +2,22 @@ import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
 
 import { dateTimePattern } from '@/utils';
 
-import { accessory } from '../schema';
+import { info } from '../schema';
 
 //* crud
-export const selectSchema = createSelectSchema(accessory);
+export const selectSchema = createSelectSchema(info);
 
 export const insertSchema = createInsertSchema(
-  accessory,
+  info,
   {
     uuid: schema => schema.uuid.length(15),
-    name: schema => schema.name.min(1),
+    user_uuid: schema => schema.user_uuid.length(15),
+    received_date: schema => schema.received_date.regex(dateTimePattern, {
+      message: 'received_date must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    zone_uuid: schema => schema.zone_uuid.length(15),
     created_by: schema => schema.created_by.length(15),
+
     created_at: schema => schema.created_at.regex(dateTimePattern, {
       message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
     }),
@@ -23,10 +28,16 @@ export const insertSchema = createInsertSchema(
   },
 ).required({
   uuid: true,
-  name: true,
+  id: true,
+  user_uuid: true,
+  zone_uuid: true,
   created_by: true,
   created_at: true,
 }).partial({
+  received_date: true,
+  is_product_received: true,
+  location: true,
+  submitted_by: true,
   updated_at: true,
   remarks: true,
 });

--- a/src/routes/work/schema.ts
+++ b/src/routes/work/schema.ts
@@ -107,6 +107,9 @@ export const order = work.table('order', {
   ),
   ready_for_delivery_date: DateTime('ready_for_delivery_date').default(sql`null`),
   bill_amount: PG_DECIMAL('bill_amount').default(sql`0`),
+  is_home_repair: boolean('is_home_repair').default(false),
+  proposed_cost: PG_DECIMAL('proposed_cost').default(sql`0`),
+  is_challan_needed: boolean('is_challan_needed').default(false),
 });
 export const statusEnum = pgEnum('status', [
   'pending',


### PR DESCRIPTION
- Updated accessory and diagnosis routes to change tags from 'hr' to 'work'.
- Modified UUID length validation in accessory, diagnosis, and warehouse schemas from 21 to 15.
- Created new info routes and handlers for managing info records.
- Implemented order routes and handlers for creating, updating, and deleting orders.
- Added new fields to the order schema including is_home_repair, proposed_cost, and is_challan_needed.
- Established relationships between orders, accessories, and diagnoses in the database.
- Enhanced validation schemas for info and order to ensure proper data structure.