### PR TITLE
feat: add delivery and work routes with value label handlers

### DIFF
--- a/src/routes/other/delivery/courier/handlers.ts
+++ b/src/routes/other/delivery/courier/handlers.ts
@@ -1,0 +1,22 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { courier } from '@/routes/delivery/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const courierPromise = db
+    .select({
+      value: courier.uuid,
+      label: sql`CONCAT(${courier.name}, '-', ${courier.branch})`,
+    })
+    .from(courier);
+
+  const data = await courierPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/delivery/courier/index.ts
+++ b/src/routes/other/delivery/courier/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/delivery/courier/routes.ts
+++ b/src/routes/other/delivery/courier/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/delivery/courier/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of courier',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/delivery/index.ts
+++ b/src/routes/other/delivery/index.ts
@@ -1,0 +1,7 @@
+import courier from './courier';
+import vehicle from './vehicle';
+
+export default [
+  courier,
+  vehicle,
+];

--- a/src/routes/other/delivery/vehicle/handlers.ts
+++ b/src/routes/other/delivery/vehicle/handlers.ts
@@ -1,0 +1,21 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { vehicle } from '@/routes/delivery/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const vehiclePromise = db
+    .select({
+      value: vehicle.uuid,
+      label: vehicle.name,
+    })
+    .from(vehicle);
+
+  const data = await vehiclePromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/delivery/vehicle/index.ts
+++ b/src/routes/other/delivery/vehicle/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/delivery/vehicle/routes.ts
+++ b/src/routes/other/delivery/vehicle/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/delivery/vehicle/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of vehicle',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/index.ts
+++ b/src/routes/other/index.ts
@@ -1,11 +1,14 @@
+import delivery from './delivery';
 // import delivery from './delivery';
 import hr from './hr';
 import store from './store';
-// import work from './work';
+import work from './work';
 
 const other = [
   ...hr,
   ...store,
+  ...work,
+  ...delivery,
 
 ];
 

--- a/src/routes/other/store/index.ts
+++ b/src/routes/other/store/index.ts
@@ -4,8 +4,11 @@ import brand from './brand';
 import category from './category';
 import floor from './floor';
 import group from './group';
+import internalTransfer from './internal_transfer';
+import model from './model';
 import product from './product';
 import purchase from './purchase';
+import purchaseEntry from './purchase_entry';
 import purchaseReturn from './purchase_return';
 import rack from './rack';
 import size from './size';
@@ -13,4 +16,4 @@ import stock from './stock';
 import vendor from './vendor';
 import warehouse from './warehouse';
 
-export default [group, category, brand, size, vendor, product, branch, stock, warehouse, rack, floor, box, purchaseReturn, purchase] as const;
+export default [group, category, brand, size, vendor, product, branch, stock, warehouse, rack, floor, box, purchaseReturn, purchase, internalTransfer, model, purchaseEntry] as const;

--- a/src/routes/other/store/internal_transfer/handlers.ts
+++ b/src/routes/other/store/internal_transfer/handlers.ts
@@ -1,0 +1,22 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { internal_transfer } from '@/routes/store/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const internalTransferPromise = db
+    .select({
+      value: internal_transfer.uuid,
+      label: sql`CONCAT('SIT',TO_CHAR(${internal_transfer.created_at}, 'YY'),' - ',TO_CHAR(${internal_transfer.id}, 'FM0000'))`,
+    })
+    .from(internal_transfer);
+
+  const data = await internalTransferPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/store/internal_transfer/index.ts
+++ b/src/routes/other/store/internal_transfer/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/store/internal_transfer/routes.ts
+++ b/src/routes/other/store/internal_transfer/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/store/internal-transfer/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of internal transfer',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/store/model/handlers.ts
+++ b/src/routes/other/store/model/handlers.ts
@@ -1,0 +1,31 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq, sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { brand, model } from '@/routes/store/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const { is_brand, brand_uuid } = c.req.query();
+  const modelPromise = db
+    .select({
+      value: model.uuid,
+      label: is_brand === 'false' ? model.name : sql`CONCAT(${model.name}, '(', ${brand.name}, ')')`,
+    })
+    .from(model)
+    .leftJoin(
+      brand,
+      eq(model.brand_uuid, brand.uuid),
+    );
+
+  if (brand_uuid) {
+    modelPromise.where(eq(model.brand_uuid, brand_uuid));
+  }
+
+  const data = await modelPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/store/model/index.ts
+++ b/src/routes/other/store/model/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/store/model/routes.ts
+++ b/src/routes/other/store/model/routes.ts
@@ -1,0 +1,29 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/store/model/value/label',
+  method: 'get',
+  tags,
+  request: {
+    query: z.object({
+      is_brand: z.string().optional(),
+      brand_uuid: z.string().optional(),
+    }),
+  },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of model',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/store/purchase_entry/handlers.ts
+++ b/src/routes/other/store/purchase_entry/handlers.ts
@@ -1,0 +1,59 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { and, eq, sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { product, purchase_entry, purchase_return_entry } from '@/routes/store/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const { is_purchase_return_entry, warehouse_uuid, purchase_uuid } = c.req.query();
+  const purchaseEntryPromise = db
+    .select({
+      value: purchase_entry.uuid,
+      label: sql`CONCAT( ${product.name}, ' - ', ${purchase_entry.serial_no})`,
+    })
+    .from(purchase_entry)
+    .leftJoin(
+      product,
+      eq(
+        purchase_entry.product_uuid,
+        product.uuid,
+      ),
+    )
+    .leftJoin(
+      purchase_return_entry,
+      eq(
+        purchase_entry.uuid,
+        purchase_return_entry.purchase_entry_uuid,
+      ),
+    );
+
+  const filters = [];
+
+  if (is_purchase_return_entry === 'false') {
+    filters.push(
+      sql`${purchase_return_entry.purchase_entry_uuid} IS NULL`,
+    );
+  }
+  if (warehouse_uuid) {
+    filters.push(
+      eq(purchase_entry.warehouse_uuid, warehouse_uuid),
+    );
+  }
+  if (purchase_uuid) {
+    filters.push(
+      eq(purchase_entry.purchase_uuid, purchase_uuid),
+    );
+  }
+
+  if (filters.length > 0) {
+    purchaseEntryPromise.where(and(...filters));
+  }
+
+  const data = await purchaseEntryPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/store/purchase_entry/index.ts
+++ b/src/routes/other/store/purchase_entry/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/store/purchase_entry/routes.ts
+++ b/src/routes/other/store/purchase_entry/routes.ts
@@ -1,0 +1,30 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/store/purchase-entry/value/label',
+  method: 'get',
+  tags,
+  request: {
+    query: z.object({
+      is_purchase_return_entry: z.string().optional(),
+      warehouse_uuid: z.string().optional(),
+      purchase_uuid: z.string().optional(),
+    }),
+  },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of purchase entry',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/work/accessory/handlers.ts
+++ b/src/routes/other/work/accessory/handlers.ts
@@ -1,0 +1,20 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { accessory } from '@/routes/work/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const accessoryPromise = db.select({
+    value: accessory.uuid,
+    label: accessory.name,
+  })
+    .from(accessory);
+
+  const data = await accessoryPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/work/accessory/index.ts
+++ b/src/routes/other/work/accessory/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/work/accessory/routes.ts
+++ b/src/routes/other/work/accessory/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/work/accessory/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of accessory',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/work/diagnosis/handlers.ts
+++ b/src/routes/other/work/diagnosis/handlers.ts
@@ -1,0 +1,22 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { diagnosis } from '@/routes/work/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const diagnosisPromise = db
+    .select({
+      value: diagnosis.uuid,
+      label: sql`CONCAT('WD',TO_CHAR(${diagnosis.created_at}, 'YY'),' - ',TO_CHAR(${diagnosis.id}, 'FM0000'))`,
+    })
+    .from(diagnosis);
+
+  const data = await diagnosisPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/work/diagnosis/index.ts
+++ b/src/routes/other/work/diagnosis/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/work/diagnosis/routes.ts
+++ b/src/routes/other/work/diagnosis/routes.ts
@@ -1,0 +1,28 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/work/diagnosis/value/label',
+  method: 'get',
+  tags,
+  // request: {
+  //   query: z.object({
+  //     category: z.string().optional(),
+  //   }),
+  // },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of diagnosis',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/work/index.ts
+++ b/src/routes/other/work/index.ts
@@ -1,0 +1,17 @@
+import accessory from './accessory';
+import diagnosis from './diagnosis';
+import order from './order';
+import problem from './problem';
+import process from './process';
+import section from './section';
+import zone from './zone';
+
+export default [
+  problem,
+  order,
+  diagnosis,
+  section,
+  process,
+  accessory,
+  zone,
+];

--- a/src/routes/other/work/order/handlers.ts
+++ b/src/routes/other/work/order/handlers.ts
@@ -1,0 +1,42 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq, sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { users } from '@/routes/hr/schema';
+import { info, order } from '@/routes/work/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const orderPromise = db
+    .select({
+      value: order.uuid,
+      label: sql`CONCAT(
+            'WO',
+            TO_CHAR(${order.created_at}, 'YY'),
+            ' - ',
+            TO_CHAR(${order.id}, 'FM0000'),
+            ' (',
+            'WI',
+            TO_CHAR(${info.created_at}, 'YY'),
+            ' - ',
+            TO_CHAR(${info.id}, 'FM0000'),
+            ')' , ' - ' ,${users.name} ,' - ' ,${users.phone}
+        )`,
+    })
+    .from(order)
+    .leftJoin(
+      info,
+      eq(order.info_uuid, info.uuid),
+    )
+    .leftJoin(
+      users,
+      eq(info.user_uuid, users.uuid),
+    );
+
+  const data = await orderPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/work/order/index.ts
+++ b/src/routes/other/work/order/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/work/order/routes.ts
+++ b/src/routes/other/work/order/routes.ts
@@ -1,0 +1,28 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/work/order/value/label',
+  method: 'get',
+  tags,
+  // request: {
+  //   query: z.object({
+  //     category: z.string().optional(),
+  //   }),
+  // },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of order',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/work/problem/handlers.ts
+++ b/src/routes/other/work/problem/handlers.ts
@@ -1,0 +1,33 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { and, eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { problem } from '@/routes/work/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const { category } = c.req.query();
+
+  const problemPromise = db
+    .select({
+      value: problem.uuid,
+      label: problem.name,
+    })
+    .from(problem);
+
+  const filters = [];
+  if (category) {
+    filters.push(eq(problem.category, category));
+  }
+
+  if (filters.length > 0) {
+    problemPromise.where(and(...filters));
+  }
+
+  const data = await problemPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/work/problem/index.ts
+++ b/src/routes/other/work/problem/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/work/problem/routes.ts
+++ b/src/routes/other/work/problem/routes.ts
@@ -1,0 +1,28 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/work/problem/value/label',
+  method: 'get',
+  tags,
+  request: {
+    query: z.object({
+      category: z.string().optional(),
+    }),
+  },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of problem',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/work/process/handlers.ts
+++ b/src/routes/other/work/process/handlers.ts
@@ -1,0 +1,22 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { process } from '@/routes/work/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const processPromise = db
+    .select({
+      value: process.uuid,
+      label: sql`CONCAT('WP',TO_CHAR(${process.created_at}, 'YY'),' - ',TO_CHAR(${process.id}, 'FM0000'))`,
+    })
+    .from(process);
+
+  const data = await processPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/work/process/index.ts
+++ b/src/routes/other/work/process/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/work/process/routes.ts
+++ b/src/routes/other/work/process/routes.ts
@@ -1,0 +1,28 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/work/process/value/label',
+  method: 'get',
+  tags,
+  // request: {
+  //   query: z.object({
+  //     category: z.string().optional(),
+  //   }),
+  // },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of process',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/work/section/handlers.ts
+++ b/src/routes/other/work/section/handlers.ts
@@ -1,0 +1,20 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { section } from '@/routes/work/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const sectionPromise = db.select({
+    value: section.uuid,
+    label: section.name,
+  })
+    .from(section);
+
+  const data = await sectionPromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/work/section/index.ts
+++ b/src/routes/other/work/section/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/work/section/routes.ts
+++ b/src/routes/other/work/section/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/work/section/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of section',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/work/zone/handlers.ts
+++ b/src/routes/other/work/zone/handlers.ts
@@ -1,0 +1,20 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { zone } from '@/routes/work/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const zonePromise = db.select({
+    value: zone.uuid,
+    label: zone.name,
+  })
+    .from(zone);
+
+  const data = await zonePromise;
+
+  return c.json(data, HSCode.OK);
+};

--- a/src/routes/other/work/zone/index.ts
+++ b/src/routes/other/work/zone/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/work/zone/routes.ts
+++ b/src/routes/other/work/zone/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/work/zone/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of zone',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;


### PR DESCRIPTION
- Implemented delivery routes for courier and vehicle, including value label handlers.
- Added work routes for accessory, diagnosis, order, problem, process, section, and zone with corresponding value label handlers.
- Enhanced store routes with internal transfer, model, and purchase entry value label handlers.
- Updated index files to include new routes and handlers.