### PR TITLE
feat(hr): implement leave policy management with CRUD operations

### DIFF
--- a/src/routes/hr/device_list/handlers.ts
+++ b/src/routes/hr/device_list/handlers.ts
@@ -1,0 +1,115 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { desc, eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { device_list, users } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(device_list).values(value).returning({
+    name: device_list.name,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(device_list)
+    .set(updates)
+    .where(eq(device_list.uuid, uuid))
+    .returning({
+      name: device_list.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(device_list)
+    .where(eq(device_list.uuid, uuid))
+    .returning({
+      name: device_list.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.department.findMany();
+
+  const deviceListPromise = db
+    .select({
+      uuid: device_list.uuid,
+      id: device_list.id,
+      name: device_list.name,
+      identifier: device_list.identifier,
+      location: device_list.location,
+      connection_status: device_list.connection_status,
+      phone_number: device_list.phone_number,
+      description: device_list.description,
+      created_by: device_list.created_by,
+      created_by_name: users.name,
+      created_at: device_list.created_at,
+      updated_at: device_list.updated_at,
+      remarks: device_list.remarks,
+    })
+    .from(device_list)
+    .leftJoin(users, eq(device_list.created_by, users.uuid))
+    .orderBy(desc(device_list.created_at));
+
+  const data = await deviceListPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const deviceListPromise = db
+    .select({
+      uuid: device_list.uuid,
+      id: device_list.id,
+      name: device_list.name,
+      identifier: device_list.identifier,
+      location: device_list.location,
+      connection_status: device_list.connection_status,
+      phone_number: device_list.phone_number,
+      description: device_list.description,
+      created_by: device_list.created_by,
+      created_by_name: users.name,
+      created_at: device_list.created_at,
+      updated_at: device_list.updated_at,
+      remarks: device_list.remarks,
+    })
+    .from(device_list)
+    .leftJoin(users, eq(device_list.created_by, users.uuid))
+    .where(eq(device_list.uuid, uuid));
+
+  const [data] = await deviceListPromise;
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/hr/device_list/index.ts
+++ b/src/routes/hr/device_list/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/hr/device_list/routes.ts
+++ b/src/routes/hr/device_list/routes.ts
@@ -8,34 +8,34 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.special_holidays'];
+const tags = ['hr.device_list'];
 
 export const list = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/device-list',
   method: 'get',
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of special-holidays',
+      'The list of device-list',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/device-list',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The special-holidays to create',
+      'The device-list to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created special-holidays',
+      'The created device-list',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/device-list/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -54,11 +54,11 @@ export const getOne = createRoute({
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested special-holidays',
+      'The requested device-list',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Device-list not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +68,24 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/device-list/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
     body: jsonContentRequired(
       patchSchema,
-      'The special-holidays updates',
+      'The device-list updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated special-holidays',
+      'The updated device-list',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Device-list not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/device-list/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,
@@ -104,11 +104,11 @@ export const remove = createRoute({
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'Special-holidays deleted',
+      description: 'Device-list deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Device-list not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),

--- a/src/routes/hr/device_list/utils.ts
+++ b/src/routes/hr/device_list/utils.ts
@@ -1,0 +1,39 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { device_list } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(device_list);
+
+export const insertSchema = createInsertSchema(
+  device_list,
+  {
+    uuid: schema => schema.uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  name: true,
+  identifier: true,
+  created_by: true,
+  created_at: true,
+}).partial({
+  location: true,
+  connection_status: true,
+  phone_number: true,
+  description: true,
+  updated_at: true,
+  remarks: true,
+}).omit({
+  id: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/hr/general_holiday/handlers.ts
+++ b/src/routes/hr/general_holiday/handlers.ts
@@ -1,0 +1,107 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { desc, eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { general_holiday, users } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(general_holiday).values(value).returning({
+    name: general_holiday.name,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(general_holiday)
+    .set(updates)
+    .where(eq(general_holiday.uuid, uuid))
+    .returning({
+      name: general_holiday.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(general_holiday)
+    .where(eq(general_holiday.uuid, uuid))
+    .returning({
+      name: general_holiday.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.department.findMany();
+
+  const generalHolidayPromise = db
+    .select({
+      uuid: general_holiday.uuid,
+      id: general_holiday.id,
+      name: general_holiday.name,
+      date: general_holiday.date,
+      created_by: general_holiday.created_by,
+      created_by_name: users.name,
+      created_at: general_holiday.created_at,
+      updated_at: general_holiday.updated_at,
+      remarks: general_holiday.remarks,
+    })
+    .from(general_holiday)
+    .leftJoin(users, eq(general_holiday.created_by, users.uuid))
+    .orderBy(desc(general_holiday.created_at));
+
+  const data = await generalHolidayPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const generalHolidayPromise = db
+    .select({
+      uuid: general_holiday.uuid,
+      id: general_holiday.id,
+      name: general_holiday.name,
+      date: general_holiday.date,
+      created_by: general_holiday.created_by,
+      created_by_name: users.name,
+      created_at: general_holiday.created_at,
+      updated_at: general_holiday.updated_at,
+      remarks: general_holiday.remarks,
+    })
+    .from(general_holiday)
+    .leftJoin(users, eq(general_holiday.created_by, users.uuid))
+    .where(eq(general_holiday.uuid, uuid));
+
+  const [data] = await generalHolidayPromise;
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/hr/general_holiday/index.ts
+++ b/src/routes/hr/general_holiday/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/hr/general_holiday/routes.ts
+++ b/src/routes/hr/general_holiday/routes.ts
@@ -8,34 +8,34 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.special_holidays'];
+const tags = ['hr.general_holiday'];
 
 export const list = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/general-holiday',
   method: 'get',
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of special-holidays',
+      'The list of general-holiday',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/general-holiday',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The special-holidays to create',
+      'The general-holiday to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created special-holidays',
+      'The created general-holiday',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/general-holiday/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -54,11 +54,11 @@ export const getOne = createRoute({
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested special-holidays',
+      'The requested general-holiday',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'General-holiday not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +68,24 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/general-holiday/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
     body: jsonContentRequired(
       patchSchema,
-      'The special-holidays updates',
+      'The general-holiday updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated special-holidays',
+      'The updated general-holiday',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'General-holiday not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/general-holiday/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,
@@ -104,11 +104,11 @@ export const remove = createRoute({
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'Special-holidays deleted',
+      description: 'General-holiday deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'General-holiday not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),

--- a/src/routes/hr/general_holiday/utils.ts
+++ b/src/routes/hr/general_holiday/utils.ts
@@ -1,0 +1,38 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { general_holiday } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(general_holiday);
+
+export const insertSchema = createInsertSchema(
+  general_holiday,
+  {
+    uuid: schema => schema.uuid.length(15),
+    date: schema => schema.date.regex(dateTimePattern, {
+      message: 'date must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    created_by: schema => schema.created_by.length(15),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  name: true,
+  date: true,
+  created_by: true,
+  created_at: true,
+}).partial({
+  updated_at: true,
+  remarks: true,
+}).omit({
+  id: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/hr/index.ts
+++ b/src/routes/hr/index.ts
@@ -1,9 +1,15 @@
 import department from './department';
 import designation from './designation';
+import device_list from './device_list';
 import employment_type from './employment_type';
+import general_holiday from './general_holiday';
+import leave_policy from './leave_policy';
+import roster from './roster';
+import shift_group from './shift_group';
+import shifts from './shifts';
 import special_holidays from './special_holidays';
 import sub_department from './sub_department';
 import users from './users';
 import workplace from './workplace';
 
-export default [department, designation, users, sub_department, workplace, employment_type, special_holidays];
+export default [department, designation, users, sub_department, workplace, employment_type, special_holidays, device_list, general_holiday, shifts, shift_group, roster, leave_policy];

--- a/src/routes/hr/leave_policy/handlers.ts
+++ b/src/routes/hr/leave_policy/handlers.ts
@@ -1,0 +1,105 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { desc, eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { leave_policy, users } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(leave_policy).values(value).returning({
+    name: leave_policy.name,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(leave_policy)
+    .set(updates)
+    .where(eq(leave_policy.uuid, uuid))
+    .returning({
+      name: leave_policy.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(leave_policy)
+    .where(eq(leave_policy.uuid, uuid))
+    .returning({
+      name: leave_policy.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.department.findMany();
+
+  const leavePolicyPromise = db
+    .select({
+      uuid: leave_policy.uuid,
+      id: leave_policy.id,
+      name: leave_policy.name,
+      created_by: leave_policy.created_by,
+      created_by_name: users.name,
+      created_at: leave_policy.created_at,
+      updated_at: leave_policy.updated_at,
+      remarks: leave_policy.remarks,
+    })
+    .from(leave_policy)
+    .leftJoin(users, eq(leave_policy.created_by, users.uuid))
+    .orderBy(desc(leave_policy.created_at));
+
+  const data = await leavePolicyPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const leavePolicyPromise = db
+    .select({
+      uuid: leave_policy.uuid,
+      id: leave_policy.id,
+      name: leave_policy.name,
+      created_by: leave_policy.created_by,
+      created_by_name: users.name,
+      created_at: leave_policy.created_at,
+      updated_at: leave_policy.updated_at,
+      remarks: leave_policy.remarks,
+    })
+    .from(leave_policy)
+    .leftJoin(users, eq(leave_policy.created_by, users.uuid))
+    .where(eq(leave_policy.uuid, uuid));
+
+  const [data] = await leavePolicyPromise;
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/hr/leave_policy/index.ts
+++ b/src/routes/hr/leave_policy/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/hr/leave_policy/routes.ts
+++ b/src/routes/hr/leave_policy/routes.ts
@@ -8,34 +8,34 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.special_holidays'];
+const tags = ['hr.leave_policy'];
 
 export const list = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/leave-policy',
   method: 'get',
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of special-holidays',
+      'The list of leave-policy',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/leave-policy',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The special-holidays to create',
+      'The leave-policy to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created special-holidays',
+      'The created leave-policy',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/leave-policy/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -54,11 +54,11 @@ export const getOne = createRoute({
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested special-holidays',
+      'The requested leave-policy',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Leave-policy not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +68,24 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/leave-policy/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
     body: jsonContentRequired(
       patchSchema,
-      'The special-holidays updates',
+      'The leave-policy updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated special-holidays',
+      'The updated leave-policy',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Leave-policy not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/leave-policy/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,
@@ -104,11 +104,11 @@ export const remove = createRoute({
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'Special-holidays deleted',
+      description: 'Leave-policy deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Leave-policy not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),

--- a/src/routes/hr/leave_policy/utils.ts
+++ b/src/routes/hr/leave_policy/utils.ts
@@ -1,0 +1,35 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { leave_policy } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(leave_policy);
+
+export const insertSchema = createInsertSchema(
+  leave_policy,
+  {
+    uuid: schema => schema.uuid.length(15),
+    name: schema => schema.name.min(1),
+    created_by: schema => schema.created_by.length(15),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  name: true,
+  created_by: true,
+  created_at: true,
+}).partial({
+  updated_at: true,
+  remarks: true,
+}).omit({
+  id: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/hr/roster/handlers.ts
+++ b/src/routes/hr/roster/handlers.ts
@@ -1,0 +1,221 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { desc, eq, sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, GetRosterCalenderByEmployeeUuidRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { roster, shift_group, shifts, users } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(roster).values(value).returning({
+    name: roster.id,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { id } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(roster)
+    .set(updates)
+    .where(eq(roster.id, id))
+    .returning({
+      name: roster.id,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { id } = c.req.valid('param');
+
+  const [data] = await db.delete(roster)
+    .where(eq(roster.id, id))
+    .returning({
+      name: roster.id,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.department.findMany();
+
+  const rosterPromise = db
+    .select({
+      id: roster.id,
+      shift_group_uuid: roster.shift_group_uuid,
+      shift_group_name: shift_group.name,
+      shifts_uuid: roster.shifts_uuid,
+      shift_name: shifts.name,
+      created_by: roster.created_by,
+      created_by_name: users.name,
+      created_at: roster.created_at,
+      updated_at: roster.updated_at,
+      remarks: roster.remarks,
+    })
+    .from(roster)
+    .leftJoin(shift_group, eq(roster.shift_group_uuid, shift_group.uuid))
+    .leftJoin(shifts, eq(roster.shifts_uuid, shifts.uuid))
+    .leftJoin(users, eq(roster.created_by, users.uuid))
+    .orderBy(desc(roster.created_at));
+
+  const data = await rosterPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { id } = c.req.valid('param');
+
+  const rosterPromise = db
+    .select({
+      id: roster.id,
+      shift_group_uuid: roster.shift_group_uuid,
+      shift_group_name: shift_group.name,
+      shifts_uuid: roster.shifts_uuid,
+      shift_name: shifts.name,
+      created_by: roster.created_by,
+      created_by_name: users.name,
+      created_at: roster.created_at,
+      updated_at: roster.updated_at,
+      remarks: roster.remarks,
+    })
+    .from(roster)
+    .leftJoin(shift_group, eq(roster.shift_group_uuid, shift_group.uuid))
+    .leftJoin(shifts, eq(roster.shifts_uuid, shifts.uuid))
+    .leftJoin(users, eq(roster.created_by, users.uuid))
+    .where(eq(roster.id, id));
+
+  const [data] = await rosterPromise;
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};
+
+export const getRosterCalenderByEmployeeUuid: AppRouteHandler<GetRosterCalenderByEmployeeUuidRoute> = async (c: any) => {
+  const { employee_uuid, year, month } = c.req.valid('param');
+
+  const specialHolidaysQuery = sql`
+                                  SELECT
+                                    SUM(sh.to_date::date - sh.from_date::date + 1) -
+                                    SUM(
+                                      CASE
+                                        WHEN sh.to_date::date > (TO_TIMESTAMP(CAST(${year} AS TEXT) || '-' || LPAD(CAST(${month} AS TEXT), 2, '0') || '-01', 'YYYY-MM-DD') + INTERVAL '1 month - 1 day')::date
+                                          THEN sh.to_date::date - (TO_TIMESTAMP(CAST(${year} AS TEXT) || '-' || LPAD(CAST(${month} AS TEXT), 2, '0') || '-01', 'YYYY-MM-DD') + INTERVAL '1 month - 1 day')::date
+                                        ELSE 0
+                                      END
+                                      +
+                                      CASE
+                                        WHEN sh.from_date::date < TO_TIMESTAMP(CAST(${year} AS TEXT) || '-' || LPAD(CAST(${month} AS TEXT), 2, '0') || '-01', 'YYYY-MM-DD')::date
+                                          THEN TO_TIMESTAMP(CAST(${year} AS TEXT) || '-' || LPAD(CAST(${month} AS TEXT), 2, '0') || '-01', 'YYYY-MM-DD')::date - sh.from_date::date
+                                        ELSE 0
+                                      END
+                                    ) AS total_special_holidays
+                                  FROM hr.special_holidays sh
+                                  WHERE
+                                  (
+                                    EXTRACT(YEAR FROM sh.to_date) > ${year}
+                                    OR (EXTRACT(YEAR FROM sh.to_date) = ${year} AND EXTRACT(MONTH FROM sh.to_date) >= ${month})
+                                  )
+                                  AND (
+                                    EXTRACT(YEAR FROM sh.from_date) < ${year}
+                                    OR (EXTRACT(YEAR FROM sh.from_date) = ${year} AND EXTRACT(MONTH FROM sh.from_date) <= ${month})
+                                  )
+                              `;
+
+  const generalHolidayQuery = sql`
+                                  SELECT
+                                    gh.date
+                                  FROM 
+                                    hr.general_holidays gh
+                                  WHERE
+                                    EXTRACT(YEAR FROM gh.date) = ${year}
+                                    AND EXTRACT(MONTH FROM gh.date) = ${month}
+                                `;
+
+  const query = sql`
+                  SELECT 
+                    employee.uuid as employee_uuid,
+                    users.name as employee_name,
+                    jsonb_agg(
+                      jsonb_build_object(
+                        'shift_group_uuid', shift_group.uuid,
+                        'shift_group_name', shift_group.name,
+                        'off_days', roster.off_days,
+                        'created_at', roster.created_at
+                      )
+                    ) FILTER (WHERE shift_group.uuid IS NOT NULL) as shift_group,
+                    jsonb_agg(
+                      jsonb_build_object(
+                        'from_date', apply_leave.from_date,
+                        'to_date', apply_leave.to_date
+                      )
+                    ) FILTER (WHERE apply_leave.from_date IS NOT NULL AND apply_leave.to_date IS NOT NULL) as applied_leaves
+                  FROM 
+                    hr.employee 
+                  LEFT JOIN
+                    hr.users ON employee.user_uuid = users.uuid
+                  LEFT JOIN 
+                    hr.shift_group ON employee.shift_group_uuid = shift_group.uuid
+                  LEFT JOIN
+                    hr.roster ON (
+                      employee.shift_group_uuid = roster.shift_group_uuid
+                      AND (
+                        EXTRACT(YEAR FROM roster.effective_date) <= ${year} AND EXTRACT(MONTH FROM roster.effective_date) <= ${month}
+                      )
+                    )
+                      LEFT JOIN
+                          hr.apply_leave ON (
+                              employee.uuid = apply_leave.employee_uuid
+                              AND apply_leave.year = ${year}
+                              AND (
+                                  EXTRACT(YEAR FROM apply_leave.to_date) > ${year}
+                                  OR (EXTRACT(YEAR FROM apply_leave.to_date) = ${year} AND EXTRACT(MONTH FROM apply_leave.to_date) >= ${month})
+                              )
+                              AND (
+                                  EXTRACT(YEAR FROM apply_leave.from_date) < ${year}
+                                  OR (EXTRACT(YEAR FROM apply_leave.from_date) = ${year} AND EXTRACT(MONTH FROM apply_leave.from_date) <= ${month})
+                              )
+                          )
+                  WHERE 
+                    employee.uuid = ${employee_uuid}
+                  GROUP BY
+                    employee.uuid, users.name
+                `;
+
+  const rosterPromise = db.execute(query);
+  const specialHolidaysPromise = db.execute(specialHolidaysQuery);
+  const generalHolidaysPromise = db.execute(generalHolidayQuery);
+
+  const data = await rosterPromise;
+  const specialHolidays = await specialHolidaysPromise;
+  const generalHolidays = await generalHolidaysPromise;
+
+  const response = {
+    roster: data.rows,
+    special_holidays: specialHolidays.rows,
+    general_holidays: generalHolidays.rows,
+  };
+
+  return c.json(response || [], HSCode.OK);
+};

--- a/src/routes/hr/roster/index.ts
+++ b/src/routes/hr/roster/index.ts
@@ -1,0 +1,14 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove)
+  .openapi(routes.getRosterCalenderByEmployeeUuid, handlers.getRosterCalenderByEmployeeUuid);
+
+export default router;

--- a/src/routes/hr/roster/routes.ts
+++ b/src/routes/hr/roster/routes.ts
@@ -8,34 +8,34 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.special_holidays'];
+const tags = ['hr.roster'];
 
 export const list = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/roster',
   method: 'get',
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of special-holidays',
+      'The list of roster',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/roster',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The special-holidays to create',
+      'The roster to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created special-holidays',
+      'The created roster',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,20 +45,22 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/roster/{id}',
   method: 'get',
   request: {
-    params: param.uuid,
+    params: z.object({
+      id: z.string(),
+    }),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested special-holidays',
+      'The requested roster',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Roster not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +70,26 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/roster/{id}',
   method: 'patch',
   request: {
-    params: param.uuid,
+    params: z.object({
+      id: z.string(),
+    }),
     body: jsonContentRequired(
       patchSchema,
-      'The special-holidays updates',
+      'The roster updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated special-holidays',
+      'The updated roster',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Roster not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,19 +100,48 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/roster/{id}',
   method: 'delete',
   request: {
-    params: param.uuid,
+    params: z.object({
+      id: z.string(),
+    }),
   },
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'Special-holidays deleted',
+      description: 'Roster deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Roster not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const getRosterCalenderByEmployeeUuid = createRoute({
+  path: '/hr/roster-calendar/by/{employee_uuid}/{year}/{month}',
+  method: 'get',
+  request: {
+    params: z.object({
+      employee_uuid: z.string(),
+      year: z.string(),
+      month: z.string(),
+    }),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The roster calendar for the employee',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'Roster calendar not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -122,3 +155,4 @@ export type CreateRoute = typeof create;
 export type GetOneRoute = typeof getOne;
 export type PatchRoute = typeof patch;
 export type RemoveRoute = typeof remove;
+export type GetRosterCalenderByEmployeeUuidRoute = typeof getRosterCalenderByEmployeeUuid;

--- a/src/routes/hr/roster/utils.ts
+++ b/src/routes/hr/roster/utils.ts
@@ -1,0 +1,40 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { roster } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(roster);
+
+export const insertSchema = createInsertSchema(
+  roster,
+  {
+    shift_group_uuid: schema => schema.shift_group_uuid.length(15),
+    shifts_uuid: schema => schema.shifts_uuid.length(15),
+    effective_date: schema => schema.effective_date.regex(dateTimePattern, {
+      message: 'effective_date must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    created_by: schema => schema.created_by.length(15),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  shift_group_uuid: true,
+  shifts_uuid: true,
+  effective_date: true,
+  created_by: true,
+  created_at: true,
+}).partial({
+  off_days: true,
+  updated_at: true,
+  remarks: true,
+}).omit({
+  id: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/hr/shift_group/handlers.ts
+++ b/src/routes/hr/shift_group/handlers.ts
@@ -1,0 +1,119 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { desc, eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { shift_group, shifts, users } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(shift_group).values(value).returning({
+    name: shift_group.name,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(shift_group)
+    .set(updates)
+    .where(eq(shift_group.uuid, uuid))
+    .returning({
+      name: shift_group.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(shift_group)
+    .where(eq(shift_group.uuid, uuid))
+    .returning({
+      name: shift_group.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.department.findMany();
+
+  const shiftGroupPromise = db
+    .select({
+      uuid: shift_group.uuid,
+      id: shift_group.id,
+      name: shift_group.name,
+      default_shift: shift_group.default_shift,
+      shifts_uuid: shift_group.shifts_uuid,
+      shifts_name: shifts.name,
+      status: shift_group.status,
+      off_days: shift_group.off_days,
+      effective_date: shift_group.effective_date,
+      created_by: shift_group.created_by,
+      created_by_name: users.name,
+      created_at: shift_group.created_at,
+      updated_at: shift_group.updated_at,
+      remarks: shift_group.remarks,
+    })
+    .from(shift_group)
+    .leftJoin(shifts, eq(shift_group.shifts_uuid, shifts.uuid))
+    .leftJoin(users, eq(shift_group.created_by, users.uuid))
+    .orderBy(desc(shift_group.created_at));
+
+  const data = await shiftGroupPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const shiftGroupPromise = db
+    .select({
+      uuid: shift_group.uuid,
+      id: shift_group.id,
+      name: shift_group.name,
+      default_shift: shift_group.default_shift,
+      shifts_uuid: shift_group.shifts_uuid,
+      shifts_name: shifts.name,
+      status: shift_group.status,
+      off_days: shift_group.off_days,
+      effective_date: shift_group.effective_date,
+      created_by: shift_group.created_by,
+      created_by_name: users.name,
+      created_at: shift_group.created_at,
+      updated_at: shift_group.updated_at,
+      remarks: shift_group.remarks,
+    })
+    .from(shift_group)
+    .leftJoin(shifts, eq(shift_group.shifts_uuid, shifts.uuid))
+    .leftJoin(users, eq(shift_group.created_by, users.uuid))
+    .where(eq(shift_group.uuid, uuid));
+
+  const [data] = await shiftGroupPromise;
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/hr/shift_group/index.ts
+++ b/src/routes/hr/shift_group/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/hr/shift_group/routes.ts
+++ b/src/routes/hr/shift_group/routes.ts
@@ -8,34 +8,34 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.special_holidays'];
+const tags = ['hr.shift_group'];
 
 export const list = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/shift-group',
   method: 'get',
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of special-holidays',
+      'The list of shift-group',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/shift-group',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The special-holidays to create',
+      'The shift-group to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created special-holidays',
+      'The created shift-group',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/shift-group/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -54,11 +54,11 @@ export const getOne = createRoute({
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested special-holidays',
+      'The requested shift-group',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Shift-group not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +68,24 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/shift-group/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
     body: jsonContentRequired(
       patchSchema,
-      'The special-holidays updates',
+      'The shift-group updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated special-holidays',
+      'The updated shift-group',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Shift-group not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/shift-group/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,
@@ -104,11 +104,11 @@ export const remove = createRoute({
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'Special-holidays deleted',
+      description: 'Shift-group deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Shift-group not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),

--- a/src/routes/hr/shift_group/utils.ts
+++ b/src/routes/hr/shift_group/utils.ts
@@ -1,0 +1,44 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { shift_group } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(shift_group);
+
+export const insertSchema = createInsertSchema(
+  shift_group,
+  {
+    uuid: schema => schema.uuid.length(15),
+    shifts_uuid: schema => schema.shifts_uuid.length(15),
+
+    effective_date: schema => schema.effective_date.regex(dateTimePattern, {
+      message: 'effective_date must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    created_by: schema => schema.created_by.length(15),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  name: true,
+  shifts_uuid: true,
+  effective_date: true,
+  created_by: true,
+  created_at: true,
+}).partial({
+  default_shift: true,
+  status: true,
+  off_days: true,
+  updated_at: true,
+  remarks: true,
+}).omit({
+  id: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/hr/shifts/handlers.ts
+++ b/src/routes/hr/shifts/handlers.ts
@@ -1,0 +1,123 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { desc, eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetOneRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { shifts, users } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(shifts).values(value).returning({
+    name: shifts.name,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(shifts)
+    .set(updates)
+    .where(eq(shifts.uuid, uuid))
+    .returning({
+      name: shifts.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(shifts)
+    .where(eq(shifts.uuid, uuid))
+    .returning({
+      name: shifts.name,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.department.findMany();
+
+  const shiftsPromise = db
+    .select({
+      uuid: shifts.uuid,
+      id: shifts.id,
+      name: shifts.name,
+      start_time: shifts.start_time,
+      end_time: shifts.end_time,
+      late_time: shifts.late_time,
+      early_exit_before: shifts.early_exit_before,
+      first_half_end: shifts.first_half_end,
+      break_time_end: shifts.break_time_end,
+      default_shift: shifts.default_shift,
+      color: shifts.color,
+      status: shifts.status,
+      created_by: shifts.created_by,
+      created_by_name: users.name,
+      created_at: shifts.created_at,
+      updated_at: shifts.updated_at,
+      remarks: shifts.remarks,
+    })
+    .from(shifts)
+    .leftJoin(users, eq(shifts.created_by, users.uuid))
+    .orderBy(desc(shifts.created_at));
+
+  const data = await shiftsPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const shiftsPromise = db
+    .select({
+      uuid: shifts.uuid,
+      id: shifts.id,
+      name: shifts.name,
+      start_time: shifts.start_time,
+      end_time: shifts.end_time,
+      late_time: shifts.late_time,
+      early_exit_before: shifts.early_exit_before,
+      first_half_end: shifts.first_half_end,
+      break_time_end: shifts.break_time_end,
+      default_shift: shifts.default_shift,
+      color: shifts.color,
+      status: shifts.status,
+      created_by: shifts.created_by,
+      created_by_name: users.name,
+      created_at: shifts.created_at,
+      updated_at: shifts.updated_at,
+      remarks: shifts.remarks,
+    })
+    .from(shifts)
+    .leftJoin(users, eq(shifts.created_by, users.uuid))
+    .where(eq(shifts.uuid, uuid));
+
+  const [data] = await shiftsPromise;
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};

--- a/src/routes/hr/shifts/index.ts
+++ b/src/routes/hr/shifts/index.ts
@@ -1,0 +1,13 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove);
+
+export default router;

--- a/src/routes/hr/shifts/routes.ts
+++ b/src/routes/hr/shifts/routes.ts
@@ -8,34 +8,34 @@ import { createRoute, z } from '@hono/zod-openapi';
 
 import { insertSchema, patchSchema, selectSchema } from './utils';
 
-const tags = ['hr.special_holidays'];
+const tags = ['hr.shifts'];
 
 export const list = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/shifts',
   method: 'get',
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       z.array(selectSchema),
-      'The list of special-holidays',
+      'The list of shifts',
     ),
   },
 });
 
 export const create = createRoute({
-  path: '/hr/special-holidays',
+  path: '/hr/shifts',
   method: 'post',
   request: {
     body: jsonContentRequired(
       insertSchema,
-      'The special-holidays to create',
+      'The shifts to create',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The created special-holidays',
+      'The created shifts',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(insertSchema),
@@ -45,7 +45,7 @@ export const create = createRoute({
 });
 
 export const getOne = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/shifts/{uuid}',
   method: 'get',
   request: {
     params: param.uuid,
@@ -54,11 +54,11 @@ export const getOne = createRoute({
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The requested special-holidays',
+      'The requested shifts',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Shifts not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),
@@ -68,24 +68,24 @@ export const getOne = createRoute({
 });
 
 export const patch = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/shifts/{uuid}',
   method: 'patch',
   request: {
     params: param.uuid,
     body: jsonContentRequired(
       patchSchema,
-      'The special-holidays updates',
+      'The shifts updates',
     ),
   },
   tags,
   responses: {
     [HSCode.OK]: jsonContent(
       selectSchema,
-      'The updated special-holidays',
+      'The updated shifts',
     ),
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Shifts not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(patchSchema)
@@ -96,7 +96,7 @@ export const patch = createRoute({
 });
 
 export const remove = createRoute({
-  path: '/hr/special-holidays/{uuid}',
+  path: '/hr/shifts/{uuid}',
   method: 'delete',
   request: {
     params: param.uuid,
@@ -104,11 +104,11 @@ export const remove = createRoute({
   tags,
   responses: {
     [HSCode.NO_CONTENT]: {
-      description: 'Special-holidays deleted',
+      description: 'Shifts deleted',
     },
     [HSCode.NOT_FOUND]: jsonContent(
       notFoundSchema,
-      'Special-holidays not found',
+      'Shifts not found',
     ),
     [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
       createErrorSchema(param.uuid),

--- a/src/routes/hr/shifts/utils.ts
+++ b/src/routes/hr/shifts/utils.ts
@@ -1,0 +1,61 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { shifts } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(shifts);
+
+export const insertSchema = createInsertSchema(
+  shifts,
+  {
+    uuid: schema => schema.uuid.length(15),
+    start_time: schema => schema.start_time.regex(dateTimePattern, {
+      message: 'start_time must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    end_time: schema => schema.end_time.regex(dateTimePattern, {
+      message: 'end_time must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    late_time: schema => schema.late_time.regex(dateTimePattern, {
+      message: 'late_time must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    early_exit_before: schema => schema.early_exit_before.regex(dateTimePattern, {
+      message: 'early_exit_before must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    first_half_end: schema => schema.first_half_end.regex(dateTimePattern, {
+      message: 'first_half_end must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    break_time_end: schema => schema.break_time_end.regex(dateTimePattern, {
+      message: 'break_time_end must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    created_by: schema => schema.created_by.length(15),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  name: true,
+  start_time: true,
+  end_time: true,
+  late_time: true,
+  early_exit_before: true,
+  first_half_end: true,
+  break_time_end: true,
+  created_by: true,
+  created_at: true,
+}).partial({
+  default_shift: true,
+  color: true,
+  status: true,
+  updated_at: true,
+  remarks: true,
+}).omit({
+  id: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/hr/workplace/handlers.ts
+++ b/src/routes/hr/workplace/handlers.ts
@@ -59,7 +59,7 @@ export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
 export const list: AppRouteHandler<ListRoute> = async (c: any) => {
   // const data = await db.query.department.findMany();
 
-  const workPromise = db
+  const workplacePromise = db
     .select({
       uuid: workplace.uuid,
       id: workplace.id,
@@ -78,7 +78,7 @@ export const list: AppRouteHandler<ListRoute> = async (c: any) => {
     .leftJoin(users, eq(workplace.created_by, users.uuid))
     .orderBy(desc(workplace.created_at));
 
-  const data = await workPromise;
+  const data = await workplacePromise;
 
   return c.json(data || [], HSCode.OK);
 };


### PR DESCRIPTION
- Added handlers for creating, updating, deleting, listing, and retrieving leave policies.
- Defined routes for leave policy operations including validation schemas.
- Integrated database operations using drizzle-orm for leave policy management.
- Created utility functions for schema validation of leave policies.
- Implemented roster management with CRUD operations and calendar retrieval by employee.
- Added handlers and routes for managing shift groups with necessary validations.
- Developed shifts management with complete CRUD functionality and validation schemas.