### PR TITLE
feat: add policy and notice routes and handlers

### DIFF
--- a/src/routes/hr/index.ts
+++ b/src/routes/hr/index.ts
@@ -13,6 +13,7 @@ import employment_type from './employment_type';
 import general_holiday from './general_holiday';
 import leave_category from './leave_category';
 import leave_policy from './leave_policy';
+import policy_and_notice from './policy_and_notice';
 import punch_log from './punch_log';
 import roster from './roster';
 import shift_group from './shift_group';
@@ -46,4 +47,5 @@ export default [
   device_permission,
   employee_education,
   punch_log,
+  policy_and_notice,
 ];

--- a/src/routes/hr/policy_and_notice/handlers.ts
+++ b/src/routes/hr/policy_and_notice/handlers.ts
@@ -1,0 +1,159 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { desc, eq } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { createToast, DataNotFound, ObjectNotFound } from '@/utils/return';
+
+import type { CreateRoute, GetNoticeRoute, GetOneRoute, GetPolicyRoute, ListRoute, PatchRoute, RemoveRoute } from './routes';
+
+import { policy_and_notice, users } from '../schema';
+
+export const create: AppRouteHandler<CreateRoute> = async (c: any) => {
+  const value = c.req.valid('json');
+
+  const [data] = await db.insert(policy_and_notice).values(value).returning({
+    name: policy_and_notice.title,
+  });
+
+  return c.json(createToast('create', data.name), HSCode.OK);
+};
+
+export const patch: AppRouteHandler<PatchRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+  const updates = c.req.valid('json');
+
+  if (Object.keys(updates).length === 0)
+    return ObjectNotFound(c);
+
+  const [data] = await db.update(policy_and_notice)
+    .set(updates)
+    .where(eq(policy_and_notice.uuid, uuid))
+    .returning({
+      name: policy_and_notice.title,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('update', data.name), HSCode.OK);
+};
+
+export const remove: AppRouteHandler<RemoveRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const [data] = await db.delete(policy_and_notice)
+    .where(eq(policy_and_notice.uuid, uuid))
+    .returning({
+      name: policy_and_notice.title,
+    });
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(createToast('delete', data.name), HSCode.OK);
+};
+
+export const list: AppRouteHandler<ListRoute> = async (c: any) => {
+  // const data = await db.query.department.findMany();
+
+  const policyAndNoticePromise = db
+    .select({
+      uuid: policy_and_notice.uuid,
+      title: policy_and_notice.title,
+      sub_title: policy_and_notice.sub_title,
+      url: policy_and_notice.url,
+      type: policy_and_notice.type,
+      created_at: policy_and_notice.created_at,
+      updated_at: policy_and_notice.updated_at,
+      created_by: policy_and_notice.created_by,
+      created_by_name: users.name,
+      remarks: policy_and_notice.remarks,
+      status: policy_and_notice.status,
+    })
+    .from(policy_and_notice)
+    .leftJoin(users, eq(policy_and_notice.created_by, users.uuid))
+    .orderBy(desc(policy_and_notice.created_at));
+
+  const data = await policyAndNoticePromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getOne: AppRouteHandler<GetOneRoute> = async (c: any) => {
+  const { uuid } = c.req.valid('param');
+
+  const policyAndNoticePromise = db
+    .select({
+      uuid: policy_and_notice.uuid,
+      title: policy_and_notice.title,
+      sub_title: policy_and_notice.sub_title,
+      url: policy_and_notice.url,
+      type: policy_and_notice.type,
+      created_at: policy_and_notice.created_at,
+      updated_at: policy_and_notice.updated_at,
+      created_by: policy_and_notice.created_by,
+      created_by_name: users.name,
+      remarks: policy_and_notice.remarks,
+      status: policy_and_notice.status,
+    })
+    .from(policy_and_notice)
+    .leftJoin(users, eq(policy_and_notice.created_by, users.uuid))
+    .where(eq(policy_and_notice.uuid, uuid));
+
+  const [data] = await policyAndNoticePromise;
+
+  if (!data)
+    return DataNotFound(c);
+
+  return c.json(data || {}, HSCode.OK);
+};
+
+export const getPolicy: AppRouteHandler<GetPolicyRoute> = async (c: any) => {
+  // const { type, status } = c.req.valid('query');
+
+  const policyPromise = db
+    .select({
+      uuid: policy_and_notice.uuid,
+      title: policy_and_notice.title,
+      type: policy_and_notice.type,
+      created_at: policy_and_notice.created_at,
+      updated_at: policy_and_notice.updated_at,
+      created_by: policy_and_notice.created_by,
+      created_by_name: users.name,
+      remarks: policy_and_notice.remarks,
+      status: policy_and_notice.status,
+    })
+    .from(policy_and_notice)
+    .leftJoin(users, eq(policy_and_notice.created_by, users.uuid))
+    .where(eq(policy_and_notice.type, 'policy'));
+
+  const data = await policyPromise;
+
+  return c.json(data || [], HSCode.OK);
+};
+
+export const getNotice: AppRouteHandler<GetNoticeRoute> = async (c: any) => {
+  // const { type, status } = c.req.valid('query');
+
+  const noticePromise = db
+    .select({
+      uuid: policy_and_notice.uuid,
+      title: policy_and_notice.title,
+      type: policy_and_notice.type,
+      created_at: policy_and_notice.created_at,
+      updated_at: policy_and_notice.updated_at,
+      created_by: policy_and_notice.created_by,
+      created_by_name: users.name,
+      remarks: policy_and_notice.remarks,
+      status: policy_and_notice.status,
+    })
+    .from(policy_and_notice)
+    .leftJoin(users, eq(policy_and_notice.created_by, users.uuid))
+    .where(eq(policy_and_notice.type, 'notice'));
+
+  const data = await noticePromise;
+
+  return c.json(data || [], HSCode.OK);
+};

--- a/src/routes/hr/policy_and_notice/index.ts
+++ b/src/routes/hr/policy_and_notice/index.ts
@@ -1,0 +1,15 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.list, handlers.list)
+  .openapi(routes.create, handlers.create)
+  .openapi(routes.getOne, handlers.getOne)
+  .openapi(routes.patch, handlers.patch)
+  .openapi(routes.remove, handlers.remove)
+  .openapi(routes.getPolicy, handlers.getPolicy)
+  .openapi(routes.getNotice, handlers.getNotice);
+
+export default router;

--- a/src/routes/hr/policy_and_notice/routes.ts
+++ b/src/routes/hr/policy_and_notice/routes.ts
@@ -1,0 +1,175 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent, jsonContentRequired } from 'stoker/openapi/helpers';
+import { createErrorSchema } from 'stoker/openapi/schemas';
+
+import { notFoundSchema } from '@/lib/constants';
+import * as param from '@/lib/param';
+import { createRoute, z } from '@hono/zod-openapi';
+
+import { insertSchema, patchSchema, selectSchema } from './utils';
+
+const tags = ['hr.policy_and_notice'];
+
+export const list = createRoute({
+  path: '/hr/policy-and-notice',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of policy-and-notice',
+    ),
+  },
+});
+
+export const create = createRoute({
+  path: '/hr/policy-and-notice',
+  method: 'post',
+  request: {
+    body: jsonContentRequired(
+      insertSchema,
+      'The policy-and-notice to create',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The created policy-and-notice',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(insertSchema),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const getOne = createRoute({
+  path: '/hr/policy-and-notice/{uuid}',
+  method: 'get',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The requested policy-and-notice',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'Policy-and-notice not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const patch = createRoute({
+  path: '/hr/policy-and-notice/{uuid}',
+  method: 'patch',
+  request: {
+    params: param.uuid,
+    body: jsonContentRequired(
+      patchSchema,
+      'The policy-and-notice updates',
+    ),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      selectSchema,
+      'The updated policy-and-notice',
+    ),
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'Policy-and-notice not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(patchSchema)
+        .or(createErrorSchema(param.uuid)),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export const remove = createRoute({
+  path: '/hr/policy-and-notice/{uuid}',
+  method: 'delete',
+  request: {
+    params: param.uuid,
+  },
+  tags,
+  responses: {
+    [HSCode.NO_CONTENT]: {
+      description: 'Policy-and-notice deleted',
+    },
+    [HSCode.NOT_FOUND]: jsonContent(
+      notFoundSchema,
+      'Policy-and-notice not found',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(param.uuid),
+      'Invalid id error',
+    ),
+  },
+});
+
+export const getPolicy = createRoute({
+  path: '/hr/policy-and-notice-only-policy',
+  method: 'get',
+  request: {
+    query: z.object({
+      type: z.string().optional(),
+      status: z.string().optional(),
+    }),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of policy-and-notice',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(z.object({
+        type: z.string().optional(),
+        status: z.string().optional(),
+      })),
+      'The validation error(s)',
+    ),
+  },
+});
+export const getNotice = createRoute({
+  path: '/hr/policy-and-notice-only-notice',
+  method: 'get',
+  request: {
+    query: z.object({
+      type: z.string().optional(),
+      status: z.string().optional(),
+    }),
+  },
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.array(selectSchema),
+      'The list of policy-and-notice',
+    ),
+    [HSCode.UNPROCESSABLE_ENTITY]: jsonContent(
+      createErrorSchema(z.object({
+        type: z.string().optional(),
+        status: z.string().optional(),
+      })),
+      'The validation error(s)',
+    ),
+  },
+});
+
+export type ListRoute = typeof list;
+export type CreateRoute = typeof create;
+export type GetOneRoute = typeof getOne;
+export type PatchRoute = typeof patch;
+export type RemoveRoute = typeof remove;
+export type GetPolicyRoute = typeof getPolicy;
+export type GetNoticeRoute = typeof getNotice;

--- a/src/routes/hr/policy_and_notice/utils.ts
+++ b/src/routes/hr/policy_and_notice/utils.ts
@@ -1,0 +1,36 @@
+import { createInsertSchema, createSelectSchema } from 'drizzle-zod';
+
+import { dateTimePattern } from '@/utils';
+
+import { policy_and_notice } from '../schema';
+
+//* crud
+export const selectSchema = createSelectSchema(policy_and_notice);
+
+export const insertSchema = createInsertSchema(
+  policy_and_notice,
+  {
+    uuid: schema => schema.uuid.length(15),
+    created_by: schema => schema.created_by.length(15),
+    created_at: schema => schema.created_at.regex(dateTimePattern, {
+      message: 'created_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+    updated_at: schema => schema.updated_at.regex(dateTimePattern, {
+      message: 'updated_at must be in the format "YYYY-MM-DD HH:MM:SS"',
+    }),
+  },
+).required({
+  uuid: true,
+  type: true,
+  title: true,
+  sub_title: true,
+  url: true,
+  status: true,
+  created_by: true,
+  created_at: true,
+}).partial({
+  updated_at: true,
+  remarks: true,
+});
+
+export const patchSchema = insertSchema.partial();

--- a/src/routes/other/hr/designation/handlers.ts
+++ b/src/routes/other/hr/designation/handlers.ts
@@ -17,5 +17,5 @@ export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
 
   const data = await designationPromise;
 
-  return c.json(data, HSCode.OK);
+  return c.json(data || [], HSCode.OK);
 };

--- a/src/routes/other/hr/employee/handlers.ts
+++ b/src/routes/other/hr/employee/handlers.ts
@@ -1,0 +1,97 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { and, eq, sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { configuration, configuration_entry, employee, leave_category, leave_policy, users } from '@/routes/hr/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const { is_hr, is_line_manager, leave_policy_required } = c.req.valid('query');
+
+  const employeePromise = db
+    .select({
+      value: employee.uuid,
+      label: users.name,
+      policy: sql`
+        jsonb_agg(
+          jsonb_build_object(
+            'name', ${leave_category.name},
+            'balance', (${configuration_entry.maximum_number_of_allowed_leaves} - COALESCE(leave_applied.total_leaves, 0)::numeric)
+          )
+        )
+      `,
+    })
+    .from(employee)
+    .leftJoin(
+      users,
+      eq(employee.user_uuid, users.uuid),
+    )
+    .leftJoin(
+      leave_policy,
+      eq(employee.leave_policy_uuid, leave_policy.uuid),
+    )
+    .leftJoin(
+      configuration,
+      eq(
+        leave_policy.uuid,
+        configuration.leave_policy_uuid,
+      ),
+    )
+    .leftJoin(
+      configuration_entry,
+      eq(
+        configuration.uuid,
+        configuration_entry.configuration_uuid,
+      ),
+    )
+    .leftJoin(
+      leave_category,
+      eq(
+        configuration_entry.leave_category_uuid,
+        leave_category.uuid,
+      ),
+    )
+    .leftJoin(
+      sql`(
+        SELECT 
+          leave_category_uuid,
+          employee_uuid,
+          year,
+          SUM(date_part('day', to_date - from_date)) AS total_leaves
+        FROM
+          hr.apply_leave
+        WHERE 
+          approval != 'rejected'
+        GROUP BY
+          leave_category_uuid, employee_uuid, year
+      ) as leave_applied`,
+      and(
+        eq(
+          leave_category.uuid,
+          sql`leave_applied.leave_category_uuid`,
+        ),
+        eq(employee.uuid, sql`leave_applied.employee_uuid`),
+      ),
+    )
+    .where(
+      and(
+        leave_policy_required
+          ? sql`${employee.leave_policy_uuid} IS NOT NULL`
+          : sql`true`,
+        is_hr === 'true'
+          ? eq(employee.is_hr, true)
+          : sql`true`,
+        is_line_manager === 'true'
+          ? eq(employee.is_line_manager, true)
+          : sql`true`,
+      ),
+    )
+    .groupBy(employee.uuid, users.name);
+
+  const data = await employeePromise;
+
+  return c.json(data || [], HSCode.OK);
+};

--- a/src/routes/other/hr/employee/index.ts
+++ b/src/routes/other/hr/employee/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/hr/employee/routes.ts
+++ b/src/routes/other/hr/employee/routes.ts
@@ -1,0 +1,32 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/hr/employee/value/label',
+  method: 'get',
+  tags,
+  request: {
+    query: z.object({
+      // Define any query parameters if needed
+      leave_policy_required: z.string().optional(),
+      is_hr: z.string().optional(),
+      is_line_manager: z.string().optional(),
+
+    }),
+  },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of employee',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/hr/employment_type/handlers.ts
+++ b/src/routes/other/hr/employment_type/handlers.ts
@@ -3,18 +3,19 @@ import type { AppRouteHandler } from '@/lib/types';
 import * as HSCode from 'stoker/http-status-codes';
 
 import db from '@/db';
-import { department } from '@/routes/hr/schema';
+import { employment_type } from '@/routes/hr/schema';
 
 import type { ValueLabelRoute } from './routes';
 
 export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
-  const departmentPromise = db.select({
-    value: department.uuid,
-    label: department.department,
-  })
-    .from(department);
+  const employmentTypePromise = db
+    .select({
+      value: employment_type.uuid,
+      label: employment_type.name,
+    })
+    .from(employment_type);
 
-  const data = await departmentPromise;
+  const data = await employmentTypePromise;
 
   return c.json(data || [], HSCode.OK);
 };

--- a/src/routes/other/hr/employment_type/index.ts
+++ b/src/routes/other/hr/employment_type/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/hr/employment_type/routes.ts
+++ b/src/routes/other/hr/employment_type/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/hr/employment-type/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of employment-type',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/hr/index.ts
+++ b/src/routes/other/hr/index.ts
@@ -1,5 +1,25 @@
 import department from './department';
 import designation from './designation';
+import employee from './employee';
+import employment_type from './employment_type';
+import leave_category from './leave_category';
+import leave_policy from './leave_policy';
+import shift_group from './shift_group';
+import shifts from './shifts';
+import sub_department from './sub_department';
 import users from './users';
+import workplace from './workplace';
 
-export default [users, designation, department];
+export default [
+  users,
+  designation,
+  department,
+  sub_department,
+  workplace,
+  employment_type,
+  shifts,
+  shift_group,
+  leave_policy,
+  leave_category,
+  employee,
+];

--- a/src/routes/other/hr/leave_category/handlers.ts
+++ b/src/routes/other/hr/leave_category/handlers.ts
@@ -1,0 +1,54 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq, sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { configuration, configuration_entry, employee, leave_category, leave_policy } from '@/routes/hr/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const { employee_uuid } = c.req.valid('query');
+
+  const leaveCategoryPromise = db
+    .select({
+      value: sql`DISTINCT leave_category.uuid`,
+      label: leave_category.name,
+    })
+    .from(leave_category)
+    .leftJoin(
+      configuration_entry,
+      eq(
+        leave_category.uuid,
+        configuration_entry.leave_category_uuid,
+      ),
+    )
+    .leftJoin(
+      configuration,
+      eq(
+        configuration_entry.configuration_uuid,
+        configuration.uuid,
+      ),
+    )
+    .leftJoin(
+      leave_policy,
+      eq(
+        configuration.leave_policy_uuid,
+        leave_policy.uuid,
+      ),
+    )
+    .leftJoin(
+      employee,
+      eq(leave_policy.uuid, employee.leave_policy_uuid),
+    )
+    .where(
+      employee_uuid
+        ? eq(employee.uuid, employee_uuid)
+        : sql`true`,
+    );
+
+  const data = await leaveCategoryPromise;
+
+  return c.json(data || [], HSCode.OK);
+};

--- a/src/routes/other/hr/leave_category/index.ts
+++ b/src/routes/other/hr/leave_category/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/hr/leave_category/routes.ts
+++ b/src/routes/other/hr/leave_category/routes.ts
@@ -1,0 +1,29 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/hr/leave-category/value/label',
+  method: 'get',
+  tags,
+  request: {
+    query: z.object({
+      // Define any query parameters if needed
+      employee_uuid: z.string().optional(),
+    }),
+  },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of leave category',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/hr/leave_policy/handlers.ts
+++ b/src/routes/other/hr/leave_policy/handlers.ts
@@ -1,0 +1,30 @@
+import type { AppRouteHandler } from '@/lib/types';
+
+import { eq, sql } from 'drizzle-orm';
+import * as HSCode from 'stoker/http-status-codes';
+
+import db from '@/db';
+import { configuration, leave_policy } from '@/routes/hr/schema';
+
+import type { ValueLabelRoute } from './routes';
+
+export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
+  const { filteredConf } = c.req.valid('query');
+
+  const leavePolicyPromise = db
+    .select({
+      value: leave_policy.uuid,
+      label: leave_policy.name,
+    })
+    .from(leave_policy)
+    .leftJoin(configuration, eq(leave_policy.uuid, configuration.leave_policy_uuid))
+    .where(
+      filteredConf === 'true'
+        ? sql`${configuration.uuid} IS NULL`
+        : sql`true`,
+    );
+
+  const data = await leavePolicyPromise;
+
+  return c.json(data || [], HSCode.OK);
+};

--- a/src/routes/other/hr/leave_policy/index.ts
+++ b/src/routes/other/hr/leave_policy/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/hr/leave_policy/routes.ts
+++ b/src/routes/other/hr/leave_policy/routes.ts
@@ -1,0 +1,29 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/hr/leave-policy/value/label',
+  method: 'get',
+  tags,
+  request: {
+    query: z.object({
+      // Define any query parameters if needed
+      filteredConf: z.string().optional(),
+    }),
+  },
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of leave policy',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/hr/shift_group/handlers.ts
+++ b/src/routes/other/hr/shift_group/handlers.ts
@@ -3,18 +3,19 @@ import type { AppRouteHandler } from '@/lib/types';
 import * as HSCode from 'stoker/http-status-codes';
 
 import db from '@/db';
-import { department } from '@/routes/hr/schema';
+import { shift_group } from '@/routes/hr/schema';
 
 import type { ValueLabelRoute } from './routes';
 
 export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
-  const departmentPromise = db.select({
-    value: department.uuid,
-    label: department.department,
-  })
-    .from(department);
+  const shiftGroupPromise = db
+    .select({
+      value: shift_group.uuid,
+      label: shift_group.name,
+    })
+    .from(shift_group);
 
-  const data = await departmentPromise;
+  const data = await shiftGroupPromise;
 
   return c.json(data || [], HSCode.OK);
 };

--- a/src/routes/other/hr/shift_group/index.ts
+++ b/src/routes/other/hr/shift_group/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/hr/shift_group/routes.ts
+++ b/src/routes/other/hr/shift_group/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/hr/shift-group/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of shift group',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/hr/shifts/handlers.ts
+++ b/src/routes/other/hr/shifts/handlers.ts
@@ -3,18 +3,19 @@ import type { AppRouteHandler } from '@/lib/types';
 import * as HSCode from 'stoker/http-status-codes';
 
 import db from '@/db';
-import { department } from '@/routes/hr/schema';
+import { shifts } from '@/routes/hr/schema';
 
 import type { ValueLabelRoute } from './routes';
 
 export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
-  const departmentPromise = db.select({
-    value: department.uuid,
-    label: department.department,
-  })
-    .from(department);
+  const shiftsPromise = db
+    .select({
+      value: shifts.uuid,
+      label: shifts.name,
+    })
+    .from(shifts);
 
-  const data = await departmentPromise;
+  const data = await shiftsPromise;
 
   return c.json(data || [], HSCode.OK);
 };

--- a/src/routes/other/hr/shifts/index.ts
+++ b/src/routes/other/hr/shifts/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/hr/shifts/routes.ts
+++ b/src/routes/other/hr/shifts/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/hr/shifts/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of shifts',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/hr/sub_department/handlers.ts
+++ b/src/routes/other/hr/sub_department/handlers.ts
@@ -3,18 +3,19 @@ import type { AppRouteHandler } from '@/lib/types';
 import * as HSCode from 'stoker/http-status-codes';
 
 import db from '@/db';
-import { department } from '@/routes/hr/schema';
+import { sub_department } from '@/routes/hr/schema';
 
 import type { ValueLabelRoute } from './routes';
 
 export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
-  const departmentPromise = db.select({
-    value: department.uuid,
-    label: department.department,
-  })
-    .from(department);
+  const subDepartmentPromise = db
+    .select({
+      value: sub_department.uuid,
+      label: sub_department.name,
+    })
+    .from(sub_department);
 
-  const data = await departmentPromise;
+  const data = await subDepartmentPromise;
 
   return c.json(data || [], HSCode.OK);
 };

--- a/src/routes/other/hr/sub_department/index.ts
+++ b/src/routes/other/hr/sub_department/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/hr/sub_department/routes.ts
+++ b/src/routes/other/hr/sub_department/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/hr/sub-department/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of sub-department',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;

--- a/src/routes/other/hr/workplace/handlers.ts
+++ b/src/routes/other/hr/workplace/handlers.ts
@@ -3,18 +3,19 @@ import type { AppRouteHandler } from '@/lib/types';
 import * as HSCode from 'stoker/http-status-codes';
 
 import db from '@/db';
-import { department } from '@/routes/hr/schema';
+import { workplace } from '@/routes/hr/schema';
 
 import type { ValueLabelRoute } from './routes';
 
 export const valueLabel: AppRouteHandler<ValueLabelRoute> = async (c: any) => {
-  const departmentPromise = db.select({
-    value: department.uuid,
-    label: department.department,
-  })
-    .from(department);
+  const workplacePromise = db
+    .select({
+      value: workplace.uuid,
+      label: workplace.name,
+    })
+    .from(workplace);
 
-  const data = await departmentPromise;
+  const data = await workplacePromise;
 
   return c.json(data || [], HSCode.OK);
 };

--- a/src/routes/other/hr/workplace/index.ts
+++ b/src/routes/other/hr/workplace/index.ts
@@ -1,0 +1,9 @@
+import { createRouter } from '@/lib/create_app';
+
+import * as handlers from './handlers';
+import * as routes from './routes';
+
+const router = createRouter()
+  .openapi(routes.valueLabel, handlers.valueLabel);
+
+export default router;

--- a/src/routes/other/hr/workplace/routes.ts
+++ b/src/routes/other/hr/workplace/routes.ts
@@ -1,0 +1,23 @@
+import * as HSCode from 'stoker/http-status-codes';
+import { jsonContent } from 'stoker/openapi/helpers';
+
+import { createRoute, z } from '@hono/zod-openapi';
+
+const tags = ['others'];
+
+export const valueLabel = createRoute({
+  path: '/other/hr/workplace/value/label',
+  method: 'get',
+  tags,
+  responses: {
+    [HSCode.OK]: jsonContent(
+      z.object({
+        value: z.string(),
+        label: z.string(),
+      }),
+      'The valueLabel of workplace',
+    ),
+  },
+});
+
+export type ValueLabelRoute = typeof valueLabel;


### PR DESCRIPTION
- Introduced new routes and handlers for managing policies and notices in the HR module.
- Updated existing HR routes to include the new policy and notice functionality.
- Enhanced error handling in department and designation handlers to return empty arrays when no data is found.
- Added comprehensive CRUD operations for policy and notice, including listing, creating, updating, and deleting entries.
- Implemented validation schemas for policy and notice data to ensure data integrity.
- Added value label routes for employee, employment type, leave category, leave policy, shift group, shifts, sub-department, and workplace.